### PR TITLE
Fix comment in chunk_replace.xml

### DIFF
--- a/extension_components/etl/templates/chunk_replace.xml
+++ b/extension_components/etl/templates/chunk_replace.xml
@@ -40,7 +40,7 @@
     </batchlet>
   </step>
 
-  <!-- バリデーション済みのデータを本テーブルに洗い替えモードでロードするステップ -->
+  <!-- バリデーション済みのデータを本テーブルにロードするステップ -->
   <step id="load">
     <listeners>
       <listener ref="nablarchStepListenerExecutor" />


### PR DESCRIPTION
「4.4.3. JOB定義ファイルとETL用JOB設定ファイルを作成する」から参照されている「JOB定義ファイルのテンプレート」中のコメントに誤りがあったため修正。