### PR TITLE
gspが使用するJDBCドライバへの依存を親POMから子POMに変更したので手順を修正した。

### DIFF
--- a/application_framework/application_framework/blank_project/CustomizeDB.rst
+++ b/application_framework/application_framework/blank_project/CustomizeDB.rst
@@ -278,6 +278,7 @@ SQL Serverの設定例
   DBに設定した通りに、configファイルにも設定すること。
   
 
+.. _customizeDB_pom_dependencies:
 
 ---------------------------
 pom.xmlファイルの修正

--- a/application_framework/application_framework/blank_project/addin_gsp.rst
+++ b/application_framework/application_framework/blank_project/addin_gsp.rst
@@ -158,104 +158,29 @@ build要素内
 
 gsp-dba-maven-pluginに対する依存関係を、H2のJDBCドライバから使用するRDBMSにあわせたものに修正する。
 
-以下に記述例を示す。
-
-
-Oracleの設定例
-^^^^^^^^^^^^^^
+POMの設定例は、 :ref:`customizeDB_pom_dependencies` を参照。
+例えば、PostgreSQLを利用する場合は以下のように設定する。
 
 .. code-block:: xml
 
-    <build>
-      <plugins>
-        <!-- 中略 -->
-        <plugin>
-          <groupId>jp.co.tis.gsp</groupId>
-          <artifactId>gsp-dba-maven-plugin</artifactId>
-          <dependencies>
-            <dependency>
-              <groupId>com.oracle</groupId>
-              <artifactId>ojdbc6</artifactId>
-              <version>11.2.0.2.0</version>
-            </dependency>
-          </dependencies>
-        </plugin>
-        <!-- 中略 -->
-      </plugins>
-    </build>
-
-
-PostgreSQLの設定例
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: xml
-
-    <build>
-      <plugins>
-        <!-- 中略 -->
-        <plugin>
-          <groupId>jp.co.tis.gsp</groupId>
-          <artifactId>gsp-dba-maven-plugin</artifactId>
-          <dependencies>
-            <dependency>
-              <groupId>org.postgresql</groupId>
-              <artifactId>postgresql</artifactId>
-              <version>9.4.1207</version>
-            </dependency>
-          </dependencies>
-        </plugin>
-        <!-- 中略 -->
-      </plugins>
-    </build>
-
-
-DB2の設定例
-^^^^^^^^^^^^^^
-
-.. code-block:: xml
-
-    <build>
-      <plugins>
-        <!-- 中略 -->
-        <plugin>
-          <groupId>jp.co.tis.gsp</groupId>
-          <artifactId>gsp-dba-maven-plugin</artifactId>
-          <dependencies>
-            <dependency>
-              <groupId>com.ibm</groupId>
-              <artifactId>db2jcc4</artifactId>
-              <version>10.5.0.7</version>
-            </dependency>
-          </dependencies>
-        </plugin>
-        <!-- 中略 -->
-      </plugins>
-    </build>
-
-
-SQLServerの設定例
-^^^^^^^^^^^^^^^^^
-
-.. code-block:: xml
-
-    <build>
-      <plugins>
-        <!-- 中略 -->
-        <plugin>
-          <groupId>jp.co.tis.gsp</groupId>
-          <artifactId>gsp-dba-maven-plugin</artifactId>
-          <dependencies>
-            <dependency>
-              <groupId>com.microsoft</groupId>
-              <artifactId>sqljdbc4</artifactId>
-              <version>4.0</version>
-            </dependency>
-          </dependencies>
-        </plugin>
-        <!-- 中略 -->
-      </plugins>
-    </build>
-
+  <build>
+    <plugins>
+      <!-- 中略 -->
+      <plugin>
+        <groupId>jp.co.tis.gsp</groupId>
+        <artifactId>gsp-dba-maven-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <!-- バージョンは適切な値に書き換えてください。 -->
+            <version>42.1.4</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <!-- 中略 -->
+    </plugins>
+  </build>
 
 data-model.edm  (src/main/resources/entity)の準備
 -------------------------------------------------

--- a/application_framework/application_framework/blank_project/addin_gsp.rst
+++ b/application_framework/application_framework/blank_project/addin_gsp.rst
@@ -156,7 +156,7 @@ nablarch.db.schema                              接続するスキーマ名
 build要素内
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-gsp-dba-maven-plugin使用時は、gsp-dba-maven-pluginで使用するJDBCドライバの設定を追加する。
+gsp-dba-maven-pluginに対する依存関係を、H2のJDBCドライバから使用するRDBMSにあわせたものに修正する。
 
 以下に記述例を示す。
 

--- a/application_framework/application_framework/blank_project/addin_gsp.rst
+++ b/application_framework/application_framework/blank_project/addin_gsp.rst
@@ -165,7 +165,6 @@ POMの設定例は、 :ref:`customizeDB_pom_dependencies` を参照。
 
   <build>
     <plugins>
-      <!-- 中略 -->
       <plugin>
         <groupId>jp.co.tis.gsp</groupId>
         <artifactId>gsp-dba-maven-plugin</artifactId>
@@ -178,7 +177,6 @@ POMの設定例は、 :ref:`customizeDB_pom_dependencies` を参照。
           </dependency>
         </dependencies>
       </plugin>
-      <!-- 中略 -->
     </plugins>
   </build>
 


### PR DESCRIPTION
gspが使用するJDBCドライバへの依存を親POMから子POMに変更したので、JDBCドライバを追加する手順を「H2のJDBCドライバから使用するRDBMSにあわせたものに修正する」という手順に改めた。