### PR TITLE
技術レビュー指摘反映

### DIFF
--- a/application_framework/adaptors/micrometer_adaptor.rst
+++ b/application_framework/adaptors/micrometer_adaptor.rst
@@ -506,7 +506,7 @@ Datadog と連携する
       <version>1.5.4</version>
     </dependency>
 
-レジストファクトリを宣言する
+レジストリファクトリを宣言する
   .. code-block:: xml
   
     <component name="meterRegistry" class="nablarch.integration.micrometer.datadog.DatadogMeterRegistryFactory">
@@ -536,7 +536,7 @@ CloudWatch と連携する
       <version>1.5.4</version>
     </dependency>
 
-レジストファクトリを宣言する
+レジストリファクトリを宣言する
   .. code-block:: xml
   
     <component name="meterRegistry" class="nablarch.integration.micrometer.statsd.StatsdMeterRegistryFactory">
@@ -629,7 +629,7 @@ Datadog は `DogStatsD(外部サイト) <https://docs.datadoghq.com/ja/developer
       <version>1.5.4</version>
     </dependency>
 
-レジストファクトリを宣言する
+レジストリファクトリを宣言する
   .. code-block:: xml
   
     <component name="meterRegistry" class="nablarch.integration.micrometer.statsd.StatsdMeterRegistryFactory">

--- a/application_framework/adaptors/micrometer_adaptor.rst
+++ b/application_framework/adaptors/micrometer_adaptor.rst
@@ -539,7 +539,7 @@ CloudWatch と連携する
 レジストリファクトリを宣言する
   .. code-block:: xml
   
-    <component name="meterRegistry" class="nablarch.integration.micrometer.statsd.StatsdMeterRegistryFactory">
+    <component name="meterRegistry" class="nablarch.integration.micrometer.cloudwatch.CloudWatchMeterRegistryFactory">
       <property name="meterBinderListProvider" ref="meterBinderListProvider" />
       <property name="applicationDisposer" ref="disposer" />
     </component>

--- a/application_framework/application_framework/libraries/repository.rst
+++ b/application_framework/application_framework/libraries/repository.rst
@@ -855,9 +855,9 @@ Initializableインタフェースを実装する
   初期化対象のオブジェクトの初期化順を意識する必要がある場合は、先に初期化を行いたいオブジェクトをより上に設定する。
   下の設定例の場合、以下の順で初期化が行われる。
   
-  #. `sampleObject`
-  #. `sampleObject3`
+  #. `sampleObject1`
   #. `sampleObject2`
+  #. `sampleObject3`
 
   .. important::
     
@@ -866,7 +866,7 @@ Initializableインタフェースを実装する
   .. code-block:: xml
 
     <!-- 初期化対象のオブジェクトの設定 -->
-    <component name="sampleObject" class="sample.SampleComponent" />
+    <component name="sampleObject1" class="sample.SampleComponent1" />
     <component name="sampleObject2" class="sample.SampleComponent2" />
     <component name="sampleObject3" class="sample.SampleComponent3" />
 
@@ -876,9 +876,9 @@ Initializableインタフェースを実装する
       <!-- initializeListプロパティにlist要素で初期化対象のオブジェクトを列挙する -->
       <property name="initializeList">
         <list>
-          <component-ref name="sampleObject"/>
-          <component-ref name="sampleObject3" />
+          <component-ref name="sampleObject1" />
           <component-ref name="sampleObject2" />
+          <component-ref name="sampleObject3" />
         </list>
       </property>
 
@@ -914,9 +914,9 @@ Disposableインタフェースを実装する
   廃棄対象のオブジェクトの廃棄順を意識する必要がある場合は、先に廃棄を行いたいオブジェクトをより **下に設定する** 。
   下の設定例の場合、以下の順で廃棄処理が行われる。
   
+  #. `sampleObject1`
   #. `sampleObject2`
   #. `sampleObject3`
-  #. `sampleObject`
 
   .. important::
     
@@ -925,7 +925,7 @@ Disposableインタフェースを実装する
   .. code-block:: xml
 
     <!-- 廃棄対象のオブジェクトの設定 -->
-    <component name="sampleObject" class="sample.SampleComponent" />
+    <component name="sampleObject1" class="sample.SampleComponent1" />
     <component name="sampleObject2" class="sample.SampleComponent2" />
     <component name="sampleObject3" class="sample.SampleComponent3" />
 
@@ -935,9 +935,9 @@ Disposableインタフェースを実装する
       <!-- disposableListプロパティにlist要素で廃棄対象のオブジェクトを列挙する -->
       <property name="disposableList">
         <list>
-          <component-ref name="sampleObject"/>
           <component-ref name="sampleObject3" />
           <component-ref name="sampleObject2" />
+          <component-ref name="sampleObject1" />
         </list>
       </property>
 


### PR DESCRIPTION
- 初期化・廃棄の処理順序例を説明しているところのコンポーネント名と並びを修正
- CloudWatch との連携の説明でファクトリの名前が Statsd 用になっていたのを修正
- レジストファクトリと誤植していたところをレジスト**リ**ファクトリに修正