### PR TITLE
Micrometerアダプタの機能拡張に関するガイドを追加

### DIFF
--- a/ja/application_framework/adaptors/micrometer_adaptor.rst
+++ b/ja/application_framework/adaptors/micrometer_adaptor.rst
@@ -1435,7 +1435,7 @@ HikariCPのコネクションプールの状態を取得する
 
 * `MBean (JMX) Monitoring and Management(外部サイト、英語) <https://github.com/brettwooldridge/HikariCP/wiki/MBean-(JMX)-Monitoring-and-Management>`_
 
-この機能を利用することで、 ``JmxGaugeMetrics`` でコネクションプールの情報を収集できるようになる。
+この機能を使用することで、 ``JmxGaugeMetrics`` でコネクションプールの情報を収集できるようになる。
 
 まず、HikariCPのMBeanで情報を公開する機能を有効にする。
 MBeanによる情報公開を有効にするには、 ``com.zaxxer.hikari.HikariDataSource`` の ``registerMbeans`` プロパティに ``true`` を設定する。
@@ -1567,7 +1567,7 @@ Micrometerが監視サービスにメトリクスを連携する方法には、�
   24-Dec-2020 17:01:31.443 情報 [logging-metrics-publisher] io.micrometer.core.instrument.logging.LoggingMeterRegistry.lambda$publish$3 db.pool.active{} value=NaN
   24-Dec-2020 17:01:31.443 情報 [logging-metrics-publisher] io.micrometer.core.instrument.logging.LoggingMeterRegistry.lambda$publish$3 db.pool.total{} value=NaN
 
-この警告ログは最初の一度だけ出力され、二回目以降は抑制されるようになっている。
+この警告ログは最初の一度だけ出力され、2回目以降は抑制されるようになっている。
 また、データベースアクセスが実行されコネクションプールが生成されると、そのあとは正常にコネクションプールの値が収集されるようになる。
 
 つまり、この警告ログはアプリケーションが正常な場合であってもタイミング次第で出力される可能性があるということになる。

--- a/ja/application_framework/adaptors/micrometer_adaptor.rst
+++ b/ja/application_framework/adaptors/micrometer_adaptor.rst
@@ -840,10 +840,9 @@ SQLの処理時間
 これにより、ここより後ろのハンドラの処理時間をメトリクスとして収集できるようになる。
 
 なお、Nablarchでは ``HandlerMetricsMetaDataBuilder`` の実装として以下の機能を提供するクラスを用意している。
+詳細は、リンク先の説明を参照のこと。
 
 * :ref:`micrometer_adaptor_http_request_process_time_metrics`
-
-詳細は、それぞれの説明を参照のこと。
 
 .. _micrometer_timer_metrics_handler_percentiles:
 

--- a/ja/application_framework/adaptors/micrometer_adaptor.rst
+++ b/ja/application_framework/adaptors/micrometer_adaptor.rst
@@ -116,8 +116,10 @@ DefaultMeterBinderListProviderを廃棄処理対象にする
 
 .. code-block:: properties
 
-  # 5秒ごとにメトリクスを出力する
+  # 確認を楽にするため、5秒ごとにメトリクスを出力する（デフォルトは1分）
   nablarch.micrometer.logging.step=5s
+  # step で指定した時間よりも早くアプリケーションが終了した場合でも廃棄処理でログが出力されるよう設定
+  nablarch.micrometer.logging.logInactive=true
 
 .. important::
 

--- a/ja/application_framework/adaptors/micrometer_adaptor.rst
+++ b/ja/application_framework/adaptors/micrometer_adaptor.rst
@@ -734,7 +734,6 @@ Datadog は `DogStatsD(外部サイト) <https://docs.datadoghq.com/ja/developer
 なお、Nablarchでは ``HandlerMetricsMetaDataBuilder`` の実装として以下の機能を提供するクラスを用意している。
 
 * :ref:`micrometer_adaptor_http_request_process_time_metrics`
-* :ref:`micrometer_adaptor_batch_process_time_metrics`
 
 詳細は、それぞれの説明を参照のこと。
 
@@ -945,67 +944,6 @@ HTTPリクエストの処理時間を収集する
   2020-10-06 13:52:10.309 [INFO ]      i.m.c.i.l.LoggingMeterRegistry: http.server.requests{class=com.nablarch.example.app.web.action.IndustryAction,exception=None,httpMethod=GET,method=find,outcome=SUCCESS,status=200} throughput=0.2/s mean=0.103277s max=0.103277s
   2020-10-06 13:52:10.310 [INFO ]      i.m.c.i.l.LoggingMeterRegistry: http.server.requests{class=com.nablarch.example.app.web.action.AuthenticationAction,exception=None,httpMethod=GET,method=index_nablarch.fw.web.HttpRequest_nablarch.fw.ExecutionContext,outcome=SUCCESS,status=200} throughput=0.2/s mean=4.7409146s max=4.7409146s
   2020-10-06 13:52:10.310 [INFO ]      i.m.c.i.l.LoggingMeterRegistry: http.server.requests{class=com.nablarch.example.app.web.action.ProjectAction,exception=None,httpMethod=GET,method=index_nablarch.fw.web.HttpRequest_nablarch.fw.ExecutionContext,outcome=SUCCESS,status=200} throughput=0.2/s mean=0.5329547s max=0.5329547s
-
-.. _micrometer_adaptor_batch_process_time_metrics:
-
-バッチの処理時間を収集する
-*********************************************************************
-
-:java:extdoc:`BatchProcessTimeMetricsMetaDataBuilder <nablarch.integration.micrometer.instrument.batch.BatchProcessTimeMetricsMetaDataBuilder>` は、 :doc:`/application_framework/application_framework/batch/nablarch_batch/index` の処理時間計測のためのメトリクスのメタ情報を構築する。
-
-本クラスは、メトリクスの名前に ``batch.process.time`` を使用する。
-
-また、本クラスは以下のタグを生成する。
-
-.. list-table::
-
-  * - タグ名
-    - 説明
-  * - ``class``
-    - アクションのクラス名（ :ref:`-requestPath <nablarch_batch-resolve_action>` から取得した値）
-  * - ``status``
-    - 直後のハンドラが返した値
-
-.. tip::
-
-  ``status`` には通常、 :ref:`プロセス終了コード <status_code_convert_handler-rules>` が設定される。
-  
-  後述する設定例のように、バッチ処理時間計測用の ``TimerMetricsHandler`` はハンドラキューの先頭に設定する。
-  この場合、 ``TimerMetricsHandler`` の直後のハンドラは :doc:`/application_framework/application_framework/handlers/standalone/status_code_convert_handler` になる。
-  したがって、 ``status`` には「プロセス終了コード」が設定されることになる。
-
-本クラスを使った場合の設定例を以下に示す。
-
-.. code-block:: xml
-
-  <!-- ハンドラキュー構成 -->
-  <list name="handlerQueue">
-
-    <!-- バッチの処理時間のメトリクス収集ハンドラ -->
-    <component class="nablarch.integration.micrometer.instrument.handler.TimerMetricsHandler">
-      <!-- レジストリファクトリが生成する MeterRegistry を meterRegistry プロパティに設定する -->
-      <property name="meterRegistry" ref="meterRegistry" />
-
-      <!-- BatchProcessTimeMetricsMetaDataBuilder を handlerMetricsMetaDataBuilder に設定する -->
-      <property name="handlerMetricsMetaDataBuilder">
-        <component class="nablarch.integration.micrometer.instrument.batch.BatchProcessTimeMetricsMetaDataBuilder" />
-      </property>
-    </component>
-
-    <!-- ステータスコードを終了コードに変換するハンドラ -->
-    <component class="nablarch.fw.handler.StatusCodeConvertHandler" />
-
-    <!-- 省略 -->
-  </list>
-
-バッチ全体の処理時間を計測するため、 ``TimerMetricsHandler`` はハンドラキューの先頭に設定する。
-
-以上の設定で、 ``LoggingMeterRegistry`` を使っていた場合は次のようなメトリクスが収集されるようになる。
-
-.. code-block:: text
-
-  12 18, 2020 10:54:47 午前 io.micrometer.core.instrument.logging.LoggingMeterRegistry lambda$publish$5
-  情報: batch.process.time{class=MetricsTestAction,status=0} throughput=0/s mean=0s max=1m 24.128662s
 
 .. _micrometer_adaptor_batch_transaction_time:
 

--- a/ja/application_framework/adaptors/micrometer_adaptor.rst
+++ b/ja/application_framework/adaptors/micrometer_adaptor.rst
@@ -1242,7 +1242,7 @@ LogPublisher を設定する
       }
   }
 
-最後に、作成したクラスを、使用する ``MeterRegistryFactory`` の ``meterBinderListProvider`` プロパティに設定する。
+最後に、 ``MeterRegistryFactory`` コンポーネントの ``meterBinderListProvider`` プロパティに、作成したカスタムの ``DefaultMeterBinderListProvider`` を設定する。
 以上で、 ``LogCountMetrics`` が使用できるようになる。
 
 ``LoggingMeterRegistry`` を使用した場合、以下のようにメトリクスが出力されることが確認できる。

--- a/ja/application_framework/adaptors/micrometer_adaptor.rst
+++ b/ja/application_framework/adaptors/micrometer_adaptor.rst
@@ -653,6 +653,114 @@ Datadog は `DogStatsD(外部サイト) <https://docs.datadoghq.com/ja/developer
     # ポートを変更
     nablarch.micrometer.statsd.port=9999
 
+アプリケーションの形式ごとに収集するメトリクスの例
+---------------------------------------------------------
+
+ここでは、アプリケーションの形式（ウェブ・バッチ）ごとに、どのようなメトリクスを収集すると良いか説明する。
+
+ウェブアプリケーションで収集するメトリクスの例
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+HTTPリクエストの処理時間
+  HTTPリクエストごとの処理時間を計測することで、以下のようなことができるようになる。
+
+  * 各URLごとにどの程度アクセスがあるか確認する
+  * リクエストの処理にどれくらい時間がかかっているか確認する
+
+  また、パーセンタイルを計測することで、大部分のリクエストがどれくらいの時間で処理できているかを確認できるようにもなる。
+
+  これらのメトリクスを収集する方法については、以下のガイドを参照のこと。
+
+  * :ref:`micrometer_timer_metrics_handler`
+  * :ref:`micrometer_timer_metrics_handler_percentiles`
+
+SQLの処理時間
+  SQLの処理時間を計測することで、以下のようなことができるようになる。
+
+  * それぞれのSQLがどの程度の時間で処理されているか確認する
+  * 想定よりも時間がかかっているSQLが無いか確認する
+
+  SQLの処理時間を計測する方法については、以下のガイドを参照のこと。
+
+  * :ref:`micrometer_sql_time`
+
+ログレベルごとの出力回数
+  ログレベルごとの出力回数を計測することで、以下のようなことができるようになる。
+
+  * 警告ログが異常な回数出力されていないか確認する（攻撃の検知）
+  * エラーログを検知する
+
+  ログレベルごとの出力回数については、以下のガイドを参照のこと。
+
+  * :ref:`micrometer_log_count`
+
+アプリケーションサーバーやライブラリが提供するリソースの情報
+  アプリケーションサーバーやライブラリが提供するリソース（スレッドプールやDBのコネクションプールなど）の状態を
+  メトリクスとして収集しておくことで、障害発生時に原因箇所を特定するための情報源として活用できるようになる。
+
+  多くのアプリケーションサーバーは、リソースの状態をJMXのMBeanを通じて公開している。
+  MBeanの情報を収集する方法については、以下のガイドを参照のこと。
+
+  * :ref:`micrometer_mbean_metrics`
+
+バッチアプリケーションで収集するメトリクスの例
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+バッチの処理時間
+  普段からバッチの処理時間を計測しておくことで、平常時の処理時間を知ることができる。
+  これにより、処理時間が平常時とは異なる値になったときに、異常を迅速に検知できるようになる。
+
+  バッチの処理時間は、 :ref:`micrometer_default_metrics` で収集される ``process.uptime`` で計測できる。
+
+トランザクション単位の処理時間
+  トランザクション単位の処理時間を計測することで、マルチスレッドのバッチが均等に処理を分散できているかなどを確認できるようになる。
+
+  また、バッチの処理時間と同様に、処理時間が平常時から逸脱したときに異常を迅速に検知することもできる。
+
+  バッチのトランザクション単位の処理時間の計測については、以下のガイドを参照のこと。
+
+  * :ref:`micrometer_adaptor_batch_transaction_time`
+
+バッチの処理件数
+  バッチの処理件数を計測することで、以下のようなことができるようになる。
+
+  * バッチの進捗状況を確認する
+  * 想定通りの速度で処理が進んでいるか確認する
+  * 想定通りの件数が処理できているか確認する
+
+  バッチの処理件数の計測については、以下のガイドを参照のこと。
+
+  * :ref:`micrometer_batch_processed_count`
+
+SQLの処理時間
+  SQLの処理時間を計測することで、以下のようなことができるようになる。
+
+  * それぞれのSQLがどの程度の時間で処理されているか確認する
+  * 想定よりも時間がかかっているSQLが無いか確認する
+
+  SQLの処理時間を計測する方法については、以下のガイドを参照のこと。
+
+  * :ref:`micrometer_sql_time`
+
+ログレベルごとの出力回数
+  ログレベルごとの出力回数を計測することで、警告ログやエラーログの検知ができるようになる。
+
+  ログレベルごとの出力回数については、以下のガイドを参照のこと。
+
+  * :ref:`micrometer_log_count`
+
+ライブラリが提供するリソースの情報
+  ライブラリが提供するリソース（DBのコネクションプールなど）の状態をメトリクスとして収集しておくことで、
+  障害発生時に原因箇所を特定するための情報源として活用できるようになる。
+
+  ライブラリによっては、リソースの状態をJMXのMBeanで公開していることがある。
+  MBeanの情報を収集する方法については、以下のガイドを参照のこと。
+
+  * :ref:`micrometer_mbean_metrics`
+
+
+.. _micrometer_timer_metrics_handler:
+
 処理時間を計測するハンドラ
 --------------------------------------------------
 
@@ -736,6 +844,8 @@ Datadog は `DogStatsD(外部サイト) <https://docs.datadoghq.com/ja/developer
 * :ref:`micrometer_adaptor_http_request_process_time_metrics`
 
 詳細は、それぞれの説明を参照のこと。
+
+.. _micrometer_timer_metrics_handler_percentiles:
 
 パーセンタイルを収集する
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1011,6 +1121,8 @@ Nablarchバッチは、 :ref:`loop_handler` によってトランザクション
   12 17, 2020 1:50:33 午後 io.micrometer.core.instrument.logging.LoggingMeterRegistry lambda$publish$5
   情報: batch.transaction.time{class=MetricsTestAction} throughput=1/s mean=2.61463556s max=3.0790852s
 
+.. _micrometer_batch_processed_count:
+
 バッチの処理件数を計測する
 --------------------------------------------------
 
@@ -1066,6 +1178,8 @@ Nablarchバッチは、 :ref:`loop_handler` によってトランザクション
   情報: batch.processed.record.count{class=MetricsTestAction} throughput=13/s
   12 23, 2020 3:23:39 午後 io.micrometer.core.instrument.logging.LoggingMeterRegistry lambda$publish$4
   情報: batch.processed.record.count{class=MetricsTestAction} throughput=13/s
+
+.. _micrometer_log_count:
 
 ログレベルごとの出力回数を計測する
 --------------------------------------------------
@@ -1167,6 +1281,8 @@ LogPublisher を設定する
   ログレベルのしきい値を下げすぎると、アプリケーションによっては大量のメトリクスが収集される可能性がある。
   使用する監視サービスの料金体系によっては使用料金が増大する可能性があるため、注意して設定すること。
 
+.. _micrometer_sql_time:
+
 SQLの処理時間を計測する
 --------------------------------------------------
 
@@ -1225,6 +1341,8 @@ SQLの処理時間を計測する
   2020-12-23 15:00:25.161 [INFO ]      i.m.c.i.l.LoggingMeterRegistry: sql.process.time{entity=com.nablarch.example.app.entity.Project,method=findAllBySqlFile,sql.id=SEARCH_PROJECT} throughput=0.6/s mean=0.003364233s max=0.0043483s
   2020-12-23 15:00:25.161 [INFO ]      i.m.c.i.l.LoggingMeterRegistry: sql.process.time{entity=com.nablarch.example.app.web.dto.ProjectDto,method=findBySqlFile,sql.id=FIND_BY_PROJECT} throughput=0.2/s mean=0.000475s max=0.0060838s
   2020-12-23 15:00:25.162 [INFO ]      i.m.c.i.l.LoggingMeterRegistry: sql.process.time{entity=com.nablarch.example.app.entity.Industry,method=findAll,sql.id=None} throughput=0.8/s mean=0.00058155s max=0.0013081s
+
+.. _micrometer_mbean_metrics:
 
 任意のMBeanから取得した値をメトリクスとして計測する
 -------------------------------------------------------------

--- a/ja/application_framework/adaptors/micrometer_adaptor.rst
+++ b/ja/application_framework/adaptors/micrometer_adaptor.rst
@@ -47,6 +47,8 @@ Micrometerでメトリクスを収集するためには、 `レジストリ(外�
 
 なお、ベースとなるアプリケーションには `ウェブアプリケーションのExample(外部サイト) <https://github.com/nablarch/nablarch-example-web>`_ を使用する。
 
+.. _micrometer_adaptor_declare_default_meter_binder_list_provider_as_component:
+
 DefaultMeterBinderListProviderをコンポーネントとして宣言する
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1069,8 +1071,108 @@ Nablarchバッチは、 :ref:`loop_handler` によってトランザクション
   12 17, 2020 1:50:33 午後 io.micrometer.core.instrument.logging.LoggingMeterRegistry lambda$publish$5
   情報: batch.transaction.time{class=MetricsTestAction} throughput=1/s mean=2.61463556s max=3.0790852s
 
+ログレベルごとの出力回数を計測する
+--------------------------------------------------
+
+:java:extdoc:`LogCountMetrics <nablarch.integration.micrometer.instrument.binder.logging.LogCountMetrics>` を使用すると、ログレベルごとの出力回数を計測できるようになる。
+これにより、特定レベルのログ出力頻度をモニターしたり、エラーログの監視などができるようになる。
+
+``LogCountMetrics`` は `Counter(外部サイト、英語)`_ を使って ``log.count`` という名前でメトリクスを収集する。
+この名前は、 :java:extdoc:`MetricsMetaData <nablarch.integration.micrometer.instrument.binder.MetricsMetaData>` を受け取る :java:extdoc:`コンストラクタ <nablarch.integration.micrometer.instrument.binder.logging.LogCountMetrics.LogCountMetrics(nablarch.integration.micrometer.instrument.binder.MetricsMetaData)>` で変更できる。
+
+また、メトリクスには以下のタグが付与される。
+
+.. list-table::
+
+  * - タグ名
+    - 説明
+  * - ``level``
+    - ログレベル。
+  * - ``logger``
+    - :java:extdoc:`LoggerManager <nablarch.core.log.LoggerManager>` からロガーを取得するときに使用した名前。
+
+LogPublisher を設定する
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``LogCountMetrics`` は、ログ出力イベントを検知するために :java:extdoc:`LogPublisher <nablarch.core.log.basic.LogPublisher>` の仕組みを使用している。
+
+したがって ``LogCountMetrics`` を使い始めるためには、まず ``LogPublisher`` の設定をする必要がある。
+``LogPublisher`` の設定については、 :ref:`log-publisher_usage` を参照のこと。
+
+カスタムのDefaultMeterBinderListProviderを作成する
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``LogCountMetrics`` は `MeterBinder(外部サイト、英語)`_ の実装クラスとして提供されている。
+したがって、 :java:extdoc:`DefaultMeterBinderListProvider <nablarch.integration.micrometer.DefaultMeterBinderListProvider>` を継承したクラスを作り、 ``LogCountMetrics`` を含んだ ``MeterBinder`` のリストを返すように実装する必要がある。
+
+.. tip::
+
+  ``DefaultMeterBinderListProvider`` の説明については、 :ref:`micrometer_adaptor_declare_default_meter_binder_list_provider_as_component` を参照。
+
+以下に、その実装例を示す。
+
+.. code-block:: java
+
+  package example.micrometer.log;
+
+  import io.micrometer.core.instrument.binder.MeterBinder;
+  import nablarch.integration.micrometer.DefaultMeterBinderListProvider;
+  import nablarch.integration.micrometer.instrument.binder.logging.LogCountMetrics;
+
+  import java.util.ArrayList;
+  import java.util.List;
+
+  public class CustomMeterBinderListProvider extends DefaultMeterBinderListProvider {
+
+      @Override
+      protected List<MeterBinder> createMeterBinderList() {
+          // デフォルトの MeterBinder リストに LogCountMetrics を追加
+          List<MeterBinder> meterBinderList = new ArrayList<>(super.createMeterBinderList());
+          meterBinderList.add(new LogCountMetrics());
+          return meterBinderList;
+      }
+  }
+
+最後に、作成したクラスを、使用する ``MeterRegistryFactory`` の ``meterBinderListProvider`` プロパティに設定する。
+以上で、 ``LogCountMetrics`` が使用できるようになる。
+
+``LoggingMeterRegistry`` を使用した場合、以下のようにメトリクスが出力されることが確認できる。
+
+.. code-block:: text
+
+  2020-12-22 14:25:36.978 [INFO ]      i.m.c.i.l.LoggingMeterRegistry: log.count{level=WARN,logger=com.nablarch.example.app.web.action.MetricsAction} throughput=0.4/s
+  2020-12-22 14:25:41.978 [INFO ]      i.m.c.i.l.LoggingMeterRegistry: log.count{level=ERROR,logger=com.nablarch.example.app.web.action.MetricsAction} throughput=1.4/s
+
+集計対象のログレベル
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+デフォルトでは、 ``WARN`` 以上のログ出力回数のみが集計の対象となる。
+
+集計対象のログレベルのしきい値は、 ``LogCountMetrics`` のコンストラクタに :java:extdoc:`LogLevel <nablarch.core.log.basic.LogLevel>` を渡すことで変更できる。
+以下の実装例では、しきい値を ``INFO`` に変更している。
+
+.. code-block:: java
+
+  // （省略）
+  import nablarch.core.log.basic.LogLevel;
+
+  public class CustomMeterBinderListProvider extends DefaultMeterBinderListProvider {
+
+      @Override
+      protected List<MeterBinder> createMeterBinderList() {
+          List<MeterBinder> meterBinderList = new ArrayList<>(super.createMeterBinderList());
+          meterBinderList.add(new LogCountMetrics(LogLevel.INFO)); // LogLevel のしきい値を指定
+          return meterBinderList;
+      }
+  }
+
+.. important::
+
+  ログレベルのしきい値を下げすぎると、アプリケーションによっては大量のメトリクスが収集される可能性がある。
+  使用する監視サービスの料金体系によっては使用料金が増大する可能性があるため、注意して設定すること。
 
 .. _MeterBinder(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.5.4/io/micrometer/core/instrument/binder/MeterBinder.html
+.. _Counter(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.5.4/io/micrometer/core/instrument/Counter.html
 .. _DatadogConfig(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-registry-datadog/1.5.4/io/micrometer/datadog/DatadogConfig.html
 .. _CloudWatchConfig(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-registry-cloudwatch2/1.5.4/io/micrometer/cloudwatch2/CloudWatchConfig.html
 .. _StatsdConfig(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-registry-statsd/1.5.4/io/micrometer/statsd/StatsdConfig.html

--- a/ja/application_framework/adaptors/micrometer_adaptor.rst
+++ b/ja/application_framework/adaptors/micrometer_adaptor.rst
@@ -984,7 +984,7 @@ SQLの処理時間
 あらかじめ用意されているHandlerMetricsMetaDataBuilderの実装
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-ここでは、Nablarchがあらかじめ用意している ``HandlerMetricsMetaDataBuilder`` の実装クラスについて紹介する。
+ここでは、Nablarchによってあらかじめ用意されている ``HandlerMetricsMetaDataBuilder`` の実装クラスについて紹介する。
 
 .. _micrometer_adaptor_http_request_process_time_metrics:
 


### PR DESCRIPTION
[メトリクス拡充対応](https://github.com/nablarch/nablarch-micrometer-adaptor/pull/8)で追加した機能についてのガイドを記載した修正です。  
修正内容については、上記PRを参照してください。

## 補足
- [時間計測ハンドラを追加、バッチ処理時間の説明を追加、HTTPリクエスト処理時間の説明を修正](https://github.com/nablarch/nablarch-document/commit/94c339034bdafb45bcbb8602057681721716c19d)

HTTPリクエストの処理時間のメトリクスについては、実装の仕組みを汎用的な時間計測ハンドラを使う形に修正しています。  
したがって、[以前追加した説明](https://github.com/nablarch/nablarch-document/commit/18dc6a0218000a4e4a381e3f36bfa7e9f23a1bf1)を修正する形になっています。
