### PR TITLE
メトリクスの収集を無効にする設定方法を追記

### DIFF
--- a/en/application_framework/adaptors/micrometer_adaptor.rst
+++ b/en/application_framework/adaptors/micrometer_adaptor.rst
@@ -526,6 +526,19 @@ Configuring the API key
 
   See `DatadogConfig (external site)`_ for other configuration.
 
+Disable the registry
+  .. code-block:: text
+
+    nablarch.micrometer.datadog.enabled=false
+    nablarch.micrometer.datadog.apiKey=XXXXXXXXXXXXXXXX
+
+  You can disable the registry by setting ``nablarch.micrometer.datadog.enabled`` to ``false`` in ``micrometer.properties``.
+  You can override this configuration by environment variable.
+  Therefor, you can enable the registry by setting ``true`` with environment variable only at production.
+
+  .. important::
+    Even if you disable the registry, you still need to set some value for ``nablarch.micrometer.datadog.apiKey``.
+    You can set dummy value to the ``apiKey``.
 
 Working with CloudWatch
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -616,6 +629,22 @@ More detailed configuration
 
     By default, the instance created by `CloudWatchAsyncClient.create() (external site) <https://javadoc.io/static/software.amazon.awssdk/cloudwatch/2.13.4/software/amazon/awssdk/services/cloudwatch/CloudWatchAsyncClient.html#create-->`_ is used.
 
+Disable the registry
+  .. code-block:: text
+
+    nablarch.micrometer.cloudwatch.enabled=false
+    nablarch.micrometer.cloudwatch.namespace=test
+
+  You can disable the registry by setting ``nablarch.micrometer.cloudwatch.enabled`` to ``false`` in ``micrometer.properties``.
+  You can override this configuration by environment variable.
+  Therefor, you can enable the registry by setting ``true`` with environment variable only at production.
+
+  .. important::
+    Even if you disable the registry, you still need to set some value for ``nablarch.micrometer.cloudwatch.namespace``.
+    You also need to set the environment variable ``AWS_REGION``.
+
+    You can set dummy values to the ``namespace`` and ``AWS_REGION``.
+
 Working with Azure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -663,6 +692,9 @@ Configuration
     The configuration file for this adapter, ``micrometer.properties``, is not used.
     However, you must place the ``micrometer.properties`` file (the content can be empty).
 
+Disable the registry
+  You can disable to send metrics by launching application without the Java 3.0 agent.
+
 Working with Datadog using StatsD
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -703,6 +735,14 @@ Write a configuration file if necessary
     # Change Port
     nablarch.micrometer.statsd.port=9999
 
+Disable the registry
+  .. code-block:: text
+
+    nablarch.micrometer.statsd.enabled=false
+
+  You can disable the registry by setting ``nablarch.micrometer.statsd.enabled`` to ``false`` in ``micrometer.properties``.
+  You can override this configuration by environment variable.
+  Therefor, you can enable the registry by setting ``true`` with environment variable only at production.
 
 .. _MeterBinder (external site): https://javadoc.io/doc/io.micrometer/micrometer-core/1.5.4/io/micrometer/core/instrument/binder/MeterBinder.html
 .. _DatadogConfig (external site): https://javadoc.io/doc/io.micrometer/micrometer-registry-datadog/1.5.4/io/micrometer/datadog/DatadogConfig.html

--- a/ja/application_framework/adaptors/micrometer_adaptor.rst
+++ b/ja/application_framework/adaptors/micrometer_adaptor.rst
@@ -527,6 +527,18 @@ APIキーを設定する
 
   その他の設定については `DatadogConfig(外部サイト、英語)`_ を参照。
 
+連携を無効にする
+  .. code-block:: text
+
+    nablarch.micrometer.datadog.enabled=false
+    nablarch.micrometer.datadog.apiKey=XXXXXXXXXXXXXXXX
+
+  ``micrometer.properties`` で ``nablarch.micrometer.datadog.enabled`` に ``false`` を設定することで、メトリクスの連携を無効にできる。
+  この設定は環境変数で上書きできるので、本番環境のみ環境変数で ``true`` に上書きして連携を有効にできる。
+
+  .. important::
+    連携を無効にした場合も、 ``nablarch.micrometer.datadog.apiKey`` には何らかの値を設定しておく必要がある。
+    値はダミーで問題ない。
 
 CloudWatch と連携する
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -615,6 +627,21 @@ CloudWatch と連携する
 
     デフォルトでは、 `CloudWatchAsyncClient.create() (外部サイト、英語) <https://javadoc.io/static/software.amazon.awssdk/cloudwatch/2.13.4/software/amazon/awssdk/services/cloudwatch/CloudWatchAsyncClient.html#create-->`_ で作成されたインスタンスが使用される。
 
+連携を無効にする
+  .. code-block:: text
+
+    nablarch.micrometer.cloudwatch.enabled=false
+    nablarch.micrometer.cloudwatch.namespace=test
+
+  ``micrometer.properties`` で ``nablarch.micrometer.cloudwatch.enabled`` に ``false`` を設定することで、メトリクスの連携を無効にできる。
+  この設定は環境変数で上書きできるので、本番環境のみ環境変数で ``true`` に上書きして連携を有効にできる。
+
+  .. important::
+    連携を無効にした場合も、 ``nablarch.micrometer.cloudwatch.namespace`` には何らかの値を設定しておく必要がある。
+    また、環境変数 ``AWS_REGION`` を設定しておく必要がある。
+
+    いずれも、値はダミーで問題ない。
+
 Azure と連携する
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -662,6 +689,9 @@ MicrometerアダプタでメトリクスをAzureに連携するための設定
   .. important::
     本アダプタ用の設定ファイルである ``micrometer.properties`` は使用できないが、ファイルは配置しておく必要がある（内容は空で構わない）。
 
+連携を無効にする
+  Java 3.0 エージェントを使用せずにアプリケーションを起動することで、メトリクスの連携を無効にできる。
+
 StatsD で連携する
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -699,6 +729,14 @@ Datadog は `DogStatsD(外部サイト) <https://docs.datadoghq.com/ja/developer
 
     # ポートを変更
     nablarch.micrometer.statsd.port=9999
+
+連携を無効にする
+  .. code-block:: text
+
+    nablarch.micrometer.statsd.enabled=false
+
+  ``micrometer.properties`` で ``nablarch.micrometer.statsd.enabled`` に ``false`` を設定することで、メトリクスの連携を無効にできる。
+  この設定は環境変数で上書きできるので、本番環境のみ環境変数で ``true`` に上書きして連携を有効にできる。
 
 アプリケーションの形式ごとに収集するメトリクスの例
 ---------------------------------------------------------


### PR DESCRIPTION
- ローカル開発時など、メトリクスの連携を停止したい場面がある
- レジストリの設定で `enabled` に `false` を指定すれば無効化できるが、そのことがガイドされていなかった
- また、レジストリの種類によっては特定の環境変数も設定しておかなければならないなどの制約もあるため、レジストリごとに無効化の手順を記載するようにした