### PR TITLE
第三者検証フィードバック　importミス修正

### DIFF
--- a/en/application_framework/adaptors/micrometer_adaptor.rst
+++ b/en/application_framework/adaptors/micrometer_adaptor.rst
@@ -1496,7 +1496,7 @@ The following is an example for a custom ``DefaultMeterBinderListProvider``.
   import nablarch.integration.micrometer.instrument.binder.jmx.JmxGaugeMetrics;
   import nablarch.integration.micrometer.instrument.binder.jmx.MBeanAttributeCondition;
 
-  import java.util.Arrays;
+  import java.util.ArrayList;
   import java.util.List;
 
   public class CustomMeterBinderListProvider extends DefaultMeterBinderListProvider {

--- a/ja/application_framework/adaptors/micrometer_adaptor.rst
+++ b/ja/application_framework/adaptors/micrometer_adaptor.rst
@@ -1480,7 +1480,7 @@ Tomcatのスレッドプールの状態を取得する
   import nablarch.integration.micrometer.instrument.binder.jmx.JmxGaugeMetrics;
   import nablarch.integration.micrometer.instrument.binder.jmx.MBeanAttributeCondition;
 
-  import java.util.Arrays;
+  import java.util.ArrayList;
   import java.util.List;
 
   public class CustomMeterBinderListProvider extends DefaultMeterBinderListProvider {


### PR DESCRIPTION
第三者検証で発覚した問題の修正。

- `java.util.ArrayList` を import しているべきところが、 `java.util.Arrays` になっていた問題を修正