### PR TITLE
lodashのバージョンアップ

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -962,9 +962,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "log-symbols": {


### PR DESCRIPTION
## 背景
- チームでtextlintを掛けるために使用しているlodashにCVE-2020-8203の問題がある。
  特に影響があるわけではないが、対応したい。
- https://github.com/lodash/lodash/wiki/Changelog に、破壊的な変更は記載されていない。

## やったこと
- package-lock.jsonに記載されているlodashのバージョンの更新

## 確認したこと
- README.mdに記載の「textlintの実行方法→疎通確認」を実行し、検知されるエラーに相違がないことを確認