### PR TITLE
同じラベルが重複して利用されていたので修正

### DIFF
--- a/en/application_framework/application_framework/messaging/mom/feature_details.rst
+++ b/en/application_framework/application_framework/messaging/mom/feature_details.rst
@@ -47,7 +47,7 @@ MOM messaging
 
 * :ref:`Resend control<message_resend_handler>`
 
-.. _data_format-formatter:
+.. _data_format-messaging-formatter:
 
 Format the display format of the output data
 --------------------------------------------------

--- a/ja/application_framework/application_framework/messaging/mom/feature_details.rst
+++ b/ja/application_framework/application_framework/messaging/mom/feature_details.rst
@@ -49,7 +49,7 @@ MOMメッセージング
 
 * :ref:`再送制御<message_resend_handler>`
 
-.. _data_format-formatter:
+.. _data_format-messaging-formatter:
 
 出力するデータの表示形式のフォーマット
 --------------------------------------------------


### PR DESCRIPTION
Jenkins 上でドキュメントをビルドしたときに以下の WARNING が出たので、その修正。

```
/var/jenkins_home/workspace/nablarch-document/ja/application_framework/application_framework/messaging/mom/feature_details.rst:57: WARNING: duplicate label data_format-formatter, other instance in /var/jenkins_home/workspace/nablarch-document/ja/application_framework/application_framework/libraries/data_io/data_format.rst
...
dumping search index in Japanese (code: ja) ... done
dumping object inventory... done
build succeeded, 1 warning.

...

/var/jenkins_home/workspace/nablarch-document/en/application_framework/application_framework/messaging/mom/feature_details.rst:55: WARNING: duplicate label data_format-formatter, other instance in /var/jenkins_home/workspace/nablarch-document/en/application_framework/application_framework/libraries/data_io/data_format.rst
...
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 1 warning.
```

サクラエディタで以下の通り修正前後のラベル名を Grep 検索し、このラベルを参照している箇所がないことを確認。

```

□検索条件  "data_format-formatter"
検索対象   *.rst
フォルダ   C:\projects\nablarch\2020\5u19リリース作業\OSSドキュメントリリース\nablarch-document
    (サブフォルダも検索)
    (英大文字小文字を区別しない)
    (正規表現:bregonig.dll Ver.3.06 with Onigmo 5.15.0)
    (文字コードセットの自動判別)
    (一致した行を出力)


C:\projects\nablarch\2020\5u19リリース作業\OSSドキュメントリリース\nablarch-document\en\application_framework\application_framework\libraries\data_io\data_format.rst(642,5)  [UTF-8]: .. _data_format-formatter:
C:\projects\nablarch\2020\5u19リリース作業\OSSドキュメントリリース\nablarch-document\ja\application_framework\application_framework\libraries\data_io\data_format.rst(667,5)  [UTF-8]: .. _data_format-formatter:
2 個が検索されました。

□検索条件  "data_format-messaging-formatter"
検索対象   *.rst
フォルダ   C:\projects\nablarch\2020\5u19リリース作業\OSSドキュメントリリース\nablarch-document
    (サブフォルダも検索)
    (英大文字小文字を区別しない)
    (正規表現:bregonig.dll Ver.3.06 with Onigmo 5.15.0)
    (文字コードセットの自動判別)
    (一致した行を出力)


C:\projects\nablarch\2020\5u19リリース作業\OSSドキュメントリリース\nablarch-document\en\application_framework\application_framework\messaging\mom\feature_details.rst(50,5)  [SJIS]: .. _data_format-messaging-formatter:
C:\projects\nablarch\2020\5u19リリース作業\OSSドキュメントリリース\nablarch-document\ja\application_framework\application_framework\messaging\mom\feature_details.rst(52,5)  [UTF-8]: .. _data_format-messaging-formatter:
2 個が検索されました。

```