### PR TITLE
日本語版と英語版の解説書にソースコード不備を修正

### DIFF
--- a/en/application_framework/application_framework/batch/nablarch_batch/getting_started/nablarch_batch/index.rst
+++ b/en/application_framework/application_framework/batch/nablarch_batch/getting_started/nablarch_batch/index.rst
@@ -67,7 +67,7 @@ Create a form that accepts input files
       @Csv(properties = {/** Property definition is omitted **/}, type = CsvType.CUSTOM)
       @CsvFormat(charset = "UTF-8", fieldSeparator = ',',
               ignoreEmptyLine = true, lineSeparator = "\r\n", quote = '"',
-              quoteMode = QuoteMode.NORMAL, requiredHeader = false)
+              quoteMode = QuoteMode.NORMAL, requiredHeader = false, emptyToNull = true)
       public class ZipCodeForm {
 
           // Excerpt of only some items

--- a/en/application_framework/application_framework/libraries/data_io/data_bind.rst
+++ b/en/application_framework/application_framework/libraries/data_io/data_bind.rst
@@ -340,7 +340,8 @@ When binding to a Java Beans class
             ignoreEmptyLine = false,
             requiredHeader = false,
             charset = "UTF−8",
-            quoteMode = CsvDataBindConfig.QuoteMode.ALL)
+            quoteMode = CsvDataBindConfig.QuoteMode.ALL, 
+            emptyToNull = true)
     public class Person {
         private Integer age;
         private String name;

--- a/en/application_framework/application_framework/web/getting_started/project_download/index.rst
+++ b/en/application_framework/application_framework/web/getting_started/project_download/index.rst
@@ -64,7 +64,6 @@ Create a download button
               <c:param name="searchForm.pageNumber" value="${searchForm.pageNumber}"/>
           </c:url>
           <n:a href="${download_uri}">
-          <n:a href="download">
               <n:write name="label" />
               <n:img src="/images/download.png" alt="Download" />
           </n:a>
@@ -83,7 +82,7 @@ Create a Bean to bind a file
               type = Csv.CsvType.CUSTOM)
       @CsvFormat(charset = "Shift_JIS", fieldSeparator = ',',ignoreEmptyLine = true,
               lineSeparator = "\r\n", quote = '"',
-              quoteMode = CsvDataBindConfig.QuoteMode.NORMAL, requiredHeader = true)
+              quoteMode = CsvDataBindConfig.QuoteMode.NORMAL, requiredHeader = true, emptyToNull = true)
       public class ProjectDownloadDto implements Serializable {
 
           // Excerpt of some items only. Getter and setter are omitted

--- a/en/application_framework/application_framework/web/getting_started/project_upload/index.rst
+++ b/en/application_framework/application_framework/web/getting_started/project_upload/index.rst
@@ -237,7 +237,7 @@ Create a bean to bind the contents of the file
               type = Csv.CsvType.CUSTOM)
       @CsvFormat(charset = "Shift_JIS", fieldSeparator = ',',ignoreEmptyLine = true,
               lineSeparator = "\r\n", quote = '"',
-              quoteMode = CsvDataBindConfig.QuoteMode.NORMAL, requiredHeader = true)
+              quoteMode = CsvDataBindConfig.QuoteMode.NORMAL, requiredHeader = true, emptyToNull = true)
       public class ProjectUploadDto implements Serializable {
 
           // Excerpt of some items only.Getter and setter are omitted

--- a/ja/application_framework/application_framework/batch/nablarch_batch/getting_started/nablarch_batch/index.rst
+++ b/ja/application_framework/application_framework/batch/nablarch_batch/getting_started/nablarch_batch/index.rst
@@ -65,7 +65,7 @@ Exampleアプリケーションを元に、ファイルをDBに登録するバ�
       @Csv(properties = {/** プロパティ定義は省略 **/}, type = CsvType.CUSTOM)
       @CsvFormat(charset = "UTF-8", fieldSeparator = ',',
               ignoreEmptyLine = true, lineSeparator = "\r\n", quote = '"',
-              quoteMode = QuoteMode.NORMAL, requiredHeader = false)
+              quoteMode = QuoteMode.NORMAL, requiredHeader = false, emptyToNull = true)
       public class ZipCodeForm {
 
           // 一部項目のみ抜粋

--- a/ja/application_framework/application_framework/libraries/data_io/data_bind.rst
+++ b/ja/application_framework/application_framework/libraries/data_io/data_bind.rst
@@ -365,7 +365,8 @@ Java Beansクラスにバインドする場合
             ignoreEmptyLine = false,
             requiredHeader = false,
             charset = "UTF-8",
-            quoteMode = CsvDataBindConfig.QuoteMode.ALL)
+            quoteMode = CsvDataBindConfig.QuoteMode.ALL,
+            emptyToNull = true)
     public class Person {
         private Integer age;
         private String name;

--- a/ja/application_framework/application_framework/web/getting_started/project_download/index.rst
+++ b/ja/application_framework/application_framework/web/getting_started/project_download/index.rst
@@ -64,7 +64,6 @@ CSVファイルをダウンロードする機能の実装方法を解説する�
               <c:param name="searchForm.pageNumber" value="${searchForm.pageNumber}"/>
           </c:url>
           <n:a href="${download_uri}">
-          <n:a href="download">
               <n:write name="label" />
               <n:img src="/images/download.png" alt="ダウンロード" />
           </n:a>
@@ -83,7 +82,7 @@ CSVファイルをダウンロードする機能の実装方法を解説する�
               type = Csv.CsvType.CUSTOM)
       @CsvFormat(charset = "Shift_JIS", fieldSeparator = ',',ignoreEmptyLine = true,
               lineSeparator = "\r\n", quote = '"',
-              quoteMode = CsvDataBindConfig.QuoteMode.NORMAL, requiredHeader = true)
+              quoteMode = CsvDataBindConfig.QuoteMode.NORMAL, requiredHeader = true, emptyToNull = true)
       public class ProjectDownloadDto implements Serializable {
 
           // 一部項目のみ抜粋。ゲッタ及びセッタは省略

--- a/ja/application_framework/application_framework/web/getting_started/project_upload/index.rst
+++ b/ja/application_framework/application_framework/web/getting_started/project_upload/index.rst
@@ -237,7 +237,7 @@ Exampleアプリケーションを元に、CSVファイルをアップロード�
               type = Csv.CsvType.CUSTOM)
       @CsvFormat(charset = "Shift_JIS", fieldSeparator = ',',ignoreEmptyLine = true,
               lineSeparator = "\r\n", quote = '"',
-              quoteMode = CsvDataBindConfig.QuoteMode.NORMAL, requiredHeader = true)
+              quoteMode = CsvDataBindConfig.QuoteMode.NORMAL, requiredHeader = true, emptyToNull = true)
       public class ProjectUploadDto implements Serializable {
 
           // 一部項目のみ抜粋。ゲッタ及びセッタは省略


### PR DESCRIPTION
日本語版と英語版の解説書にソースコード不備を修正
・downloadのリンクに不要なソースコードを削除
・CsvFormatの必須項目を追加