### PR TITLE
名前付きパラメータの記載ミス修正

### DIFF
--- a/en/application_framework/application_framework/libraries/database/database.rst
+++ b/en/application_framework/application_framework/libraries/database/database.rst
@@ -630,7 +630,7 @@ SQL
     from
       user
     where
-      $if (userName) {user_name like :user_name%}
+      $if (userName) {user_name like :userName%}
       and $if (userKbn) {user_kbn in ('1', '2')}
       and birthday = :birthday
 
@@ -752,7 +752,7 @@ SQL
     from
       user
     where
-      user_name = :user_name
+      user_name = :userName
     $sort(sortId) {
       (user_id_asc  user_id asc)
       (user_id_desc user_id desc)

--- a/ja/application_framework/application_framework/libraries/database/database.rst
+++ b/ja/application_framework/application_framework/libraries/database/database.rst
@@ -677,7 +677,7 @@ SQL
     from
       user
     where
-      $if (userName) {user_name like :user_name%}
+      $if (userName) {user_name like :userName%}
       and $if (userKbn) {user_kbn in ('1', '2')}
       and birthday = :birthday
 
@@ -808,7 +808,7 @@ SQL
     from
       user
     where
-      user_name = :user_name
+      user_name = :userName
     $sort(sortId) {
       (user_id_asc  user_id asc)
       (user_id_desc user_id desc)


### PR DESCRIPTION
名前付きパラメータはBeanのプロパティ名と合わせる必要があるがスネークケースになっていてプロパティ名と一致していなかったので修正。