### PR TITLE
NAB-433 Oracle JDBCドライバは、実際にはMavenCentralからinstall可能である点をDocumentに記載

### DIFF
--- a/en/application_framework/application_framework/blank_project/CustomizeDB.rst
+++ b/en/application_framework/application_framework/blank_project/CustomizeDB.rst
@@ -48,34 +48,12 @@ H2
 
 In the case of H2, registration is not required because the JDBC driver is published in the Maven central repository.
 
+
 Oracle
 ------
 
-Since the Oracle JDBC driver is not published in the Maven central repository, it is necessary to register it in the local Maven repository.
+In the case of Oracle, registration is not required because the JDBC driver is published in the Maven central repository.
 
-The JDBC driver can be downloaded from the following site on the Internet.
-
-.. list-table::
-  :header-rows: 1
-  :class: white-space-normal
-  :widths: 6,10
-
-
-  * - Distribution site name
-    - URL
-
-  * - JDBC, SQLJ, Oracle JPublisher and Universal Connection Pool (UCP)
-    - http://www.oracle.com/technetwork/jp/database/features/jdbc/index-099275-ja.html (External site)
-
-An example of the command to register the downloaded JDBC driver to the local Maven repository is shown below.
-
-.. code-block:: bash
-
-    mvn install:install-file -DgroupId=com.oracle -DartifactId=ojdbc6 -Dversion=11.2.0.4.0 -Dpackaging=jar -Dfile=ojdbc6.jar
-
-.. tip::
-
-  `maven-install-plugin(external site) <https://maven.apache.org/plugins/maven-install-plugin/install-file-mojo.html>`_ is used for registration to the local Maven repository.
 
 PostgreSQL
 ------------------

--- a/ja/application_framework/application_framework/blank_project/CustomizeDB.rst
+++ b/ja/application_framework/application_framework/blank_project/CustomizeDB.rst
@@ -48,34 +48,11 @@ H2
 
 H2の場合、JDBCドライバはMavenのセントラルリポジトリに公開されているため登録は不要である。
 
+
 Oracle
 ------
 
-OracleのJDBCドライバはMavenのセントラルリポジトリに公開されていないため、ローカルのMavenリポジトリに登録する必要がある。
-
-JDBCドライバをWebから取得する場合は、以下のサイトから入手する。
-
-.. list-table::
-  :header-rows: 1
-  :class: white-space-normal
-  :widths: 6,10
-
-
-  * - 配布サイトの名前
-    - URL
-
-  * - JDBC, SQLJ, Oracle JPublisher and Universal Connection Pool (UCP)
-    - http://www.oracle.com/technetwork/jp/database/features/jdbc/index-099275-ja.html (外部サイト)
-
-以下に、入手したJDBCドライバをローカルのMavenリポジトリに登録するコマンドの例を示す。
-
-.. code-block:: bash
-
-    mvn install:install-file -DgroupId=com.oracle -DartifactId=ojdbc6 -Dversion=11.2.0.4.0 -Dpackaging=jar -Dfile=ojdbc6.jar
-
-.. tip::
-
-  ローカルのMavenリポジトリへの登録には、`maven-install-plugin(外部サイト、英語) <https://maven.apache.org/plugins/maven-install-plugin/install-file-mojo.html>`_  を使用している。
+Oracleの場合、JDBCドライバはMavenのセントラルリポジトリに公開されているため登録は不要である。
 
 
 PostgreSQL


### PR DESCRIPTION
NAB-433 Oracle JDBCドライバは、実際にはMavenCentralからinstall可能である点をDocumentに記載
https://nablarch.atlassian.net/browse/NAB-433