### PR TITLE
使用不許可APIチェックツールについてブランクプロジェクトでは事前構成済みであることを明記

### DIFF
--- a/en/development_tools/java_static_analysis/index.rst
+++ b/en/development_tools/java_static_analysis/index.rst
@@ -74,9 +74,19 @@ By making effective use of this, it is possible to commit the code will in accor
 Check if unauthorized APIs are being used
 -------------------------------------------------
 
-`nablarch-intellij-plugin <https://github.com/nablarch/nablarch-intellij-plugin/tree/master/en>`_ is used for this check.
-nablarch-intellij-plugin is a plugin to use IntelliJ IDEA for supporting Nablarch development and has the following functions.
+We prepared two tools for this check: the IntelliJ IDEA plugin and the SpotBugs plugin which does not depend on IntelliJ IDEA.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+use nablarch-intellij-plugin
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`nablarch-intellij-plugin <https://github.com/nablarch/nablarch-intellij-plugin/tree/master/en>`_  is a plugin to use IntelliJ IDEA for supporting Nablarch development and has the following functions.
 
 * Throws a warning if Nablarch private API is used.
 * Throws warning if Java API registered in the black list is used.
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+use Unauthorized API Check Tool
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Unauthorized API Check Tool is provided as a SpotBugs plugin. 
+See `Nablarch style guide <https://github.com/nablarch-development-standards/nablarch-style-guide/blob/master/en/java/staticanalysis/unpublished-api/README.md>`_ for detailed specifications and instructions.
+Note that the blank project has been preconfigured to `run in Maven <https://github.com/nablarch-development-standards/nablarch-style-guide/blob/master/en/java/staticanalysis/spotbugs/docs/Maven-settings.md>`_ , so it can be checked immediately.

--- a/en/development_tools/java_static_analysis/index.rst
+++ b/en/development_tools/java_static_analysis/index.rst
@@ -74,7 +74,7 @@ By making effective use of this, it is possible to commit the code will in accor
 Check if unauthorized APIs are being used
 -------------------------------------------------
 
-We prepared two tools for this check: the IntelliJ IDEA plugin and the SpotBugs plugin which does not depend on IntelliJ IDEA.
+We provide two tools for this check: the IntelliJ IDEA plugin and the SpotBugs plugin which does not depend on IntelliJ IDEA.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 use nablarch-intellij-plugin

--- a/en/development_tools/java_static_analysis/index.rst
+++ b/en/development_tools/java_static_analysis/index.rst
@@ -77,7 +77,7 @@ Check if unauthorized APIs are being used
 We provide two tools for this check: the IntelliJ IDEA plugin and the SpotBugs plugin which does not depend on IntelliJ IDEA.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-use nablarch-intellij-plugin
+Use nablarch-intellij-plugin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `nablarch-intellij-plugin <https://github.com/nablarch/nablarch-intellij-plugin/tree/master/en>`_  is a plugin to use IntelliJ IDEA for supporting Nablarch development and has the following functions.
 
@@ -85,7 +85,7 @@ use nablarch-intellij-plugin
 * Throws warning if Java API registered in the black list is used.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-use Unauthorized API Check Tool
+Use Unauthorized API Check Tool
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Unauthorized API Check Tool is provided as a SpotBugs plugin. 
 See `Nablarch style guide <https://github.com/nablarch-development-standards/nablarch-style-guide/blob/master/en/java/staticanalysis/unpublished-api/README.md>`_ for detailed specifications and instructions.

--- a/ja/development_tools/java_static_analysis/index.rst
+++ b/ja/development_tools/java_static_analysis/index.rst
@@ -74,9 +74,19 @@ IntelliJ IDEAでは、VCSへのコミット時にコミット対象のファイ�
 許可していないAPIが使用されていないかチェックする
 -------------------------------------------------
 
-このチェックには、 `nablarch-intellij-plugin <https://github.com/nablarch/nablarch-intellij-plugin>`_ を使用する。
-nablarch-intellij-pluginはNablarch開発を支援するためのIntelliJ IDEA用のプラグインであり、下記の機能を有している。
+このチェックにはIntelliJ IDEAのプラグインとIntelliJ IDEAに依存しないSpotBugsプラグインの2種類のツールを提供している。
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+nablarch-intellij-pluginを使用する
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`nablarch-intellij-plugin <https://github.com/nablarch/nablarch-intellij-plugin>`_ はNablarch開発を支援するためのIntelliJ IDEA用のプラグインであり、下記の機能を有している。
 
 * Nablarch非公開APIが使用されている場合に警告を出す
 * ブラックリストに登録したJava APIが使用されている場合に警告を出す
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+使用不許可APIチェックツールを使用する
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+使用不許可APIチェックツールはSpotBugsのプラグインとして作成されたツールである。
+詳細な仕様と実行方法は `Nablarchスタイルガイドの解説 <https://github.com/nablarch-development-standards/nablarch-style-guide/blob/master/java/staticanalysis/unpublished-api/README.md>`_ を参照。
+なお、ブランクプロジェクトには `Mavenで実行するための設定 <https://github.com/nablarch-development-standards/nablarch-style-guide/blob/master/java/staticanalysis/spotbugs/docs/Maven-settings.md>`_ をあらかじめ設定してあるため、すぐにチェックを実施することが可能である。


### PR DESCRIPTION
[nablarch-style-guide](https://github.com/nablarch-development-standards/nablarch-style-guide)側で言及することも考えたが、スタイルガイドは汎用的なもののため、見送り。
Java静的解析はIntelliJを前提にした記載になっているため追記する場所に迷ったが、IntelliJに依存しないことを明記した上でJava静的解析の章に追記。