### PR TITLE
セッションIDを変更するだけの場合はCSRFトークンの再生成が必要であることを記載

### DIFF
--- a/en/application_framework/application_framework/libraries/session_store.rst
+++ b/en/application_framework/application_framework/libraries/session_store.rst
@@ -249,8 +249,19 @@ Login to the application
     // Change session ID before login
     SessionUtil.changeId(ctx);
 
+    // Regenerate CSRF token (If you are using the CSRF Token Verification Handler)
+    CsrfTokenUtil.regenerateCsrfToken(ctx);
+
     // Save login user information in session store
     SessionUtil.put(ctx, "user", user, "db");
+
+.. important::
+  If all of the following conditions are met, a CSRF token must be regenerated at login.
+
+  * Using the :ref:`csrf_token_verification_handler`
+  * Only change session ID at login (keep session information)
+
+  See :ref:`csrf_token_verification_handler-regeneration` for more information.
 
 Logout from the application
   .. code-block:: java

--- a/ja/application_framework/application_framework/libraries/session_store.rst
+++ b/ja/application_framework/application_framework/libraries/session_store.rst
@@ -250,8 +250,19 @@ Oracleで正常に動作しないケースがあるため、 `SESSION_ID` はCHA
     // ログイン前にセッションIDを変更する
     SessionUtil.changeId(ctx);
 
+    // CSRFトークンを再生成する（CSRFトークン検証ハンドラを使用している場合）
+    CsrfTokenUtil.regenerateCsrfToken(ctx);
+
     // ログインユーザの情報をセッションストアに保存
     SessionUtil.put(ctx, "user", user, "db");
+
+.. important::
+  以下の条件を全て満たす場合、ログインのときにCSRFトークンの再生成が必要になる。
+
+  * :ref:`csrf_token_verification_handler` を使用している
+  * ログイン時にセッションIDの変更のみを行う（セッション情報は維持する）
+
+  詳しくは :ref:`csrf_token_verification_handler-regeneration` を参照。
 
 アプリケーションからログアウトする
   .. code-block:: java


### PR DESCRIPTION
[6.2.18.5. CSRFトークンの再生成を行う](https://nablarch.github.io/docs/5u20/doc/application_framework/application_framework/handlers/web/csrf_token_verification_handler.html#csrf-token-verification-handler-regeneration) にて、ログイン時にセッションIDの再生成だけを行う場合は CSRF トークンの再生成が必要であることが説明されていたので、ログイン側の説明の実装を修正し注釈を追加しました。