### PR TITLE
H2のバージョンを更新

### DIFF
--- a/en/application_framework/application_framework/blank_project/CustomizeDB.rst
+++ b/en/application_framework/application_framework/blank_project/CustomizeDB.rst
@@ -304,7 +304,7 @@ H2 configuration example (default)
         <dependency>
           <groupId>com.h2database</groupId>
           <artifactId>h2</artifactId>
-          <version>1.4.191</version>
+          <version>2.1.214</version>
           <scope>runtime</scope>
         </dependency>
         <!-- Omitted -->
@@ -419,7 +419,7 @@ An example of the dependency element described by default is shown.
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.4.191</version>
+      <version>2.1.214</version>
       <scope>runtime</scope>
     </dependency>
     <!-- Omitted -->

--- a/en/development_tools/toolbox/SqlExecutor/SqlExecutor.rst
+++ b/en/development_tools/toolbox/SqlExecutor/SqlExecutor.rst
@@ -188,7 +188,6 @@ Hereinafter, configuration examples will be described for each type of database.
       <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
-        <version>1.3.176</version>
         <scope>runtime</scope>
       </dependency>
     </dependencies>

--- a/ja/application_framework/application_framework/blank_project/CustomizeDB.rst
+++ b/ja/application_framework/application_framework/blank_project/CustomizeDB.rst
@@ -307,7 +307,7 @@ H2の設定例(デフォルト)
         <dependency>
           <groupId>com.h2database</groupId>
           <artifactId>h2</artifactId>
-          <version>1.4.191</version>
+          <version>2.1.214</version>
           <scope>runtime</scope>
         </dependency>
         <!-- 中略 -->
@@ -422,7 +422,7 @@ dependencies要素内で、JDBCドライバの依存関係が記述されてい�
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.4.191</version>
+      <version>2.1.214</version>
       <scope>runtime</scope>
     </dependency>
     <!-- 中略 -->

--- a/ja/development_tools/toolbox/SqlExecutor/SqlExecutor.rst
+++ b/ja/development_tools/toolbox/SqlExecutor/SqlExecutor.rst
@@ -191,7 +191,6 @@ pom.xml中の「使用するRDBMSにあわせて、下記JDBCドライバの dep
       <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
-        <version>1.3.176</version>
         <scope>runtime</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
アーキタイプのH2のバージョン更新対応が入ったが、解説書に記載されているデフォルトの設定を説明している記述のバージョンが古いままになっていた。
実際のバージョンに合わせて記載を修正。

他にh2のバージョンの記載がないか確認するため、 git grep で以下のように検索を行った。

```
$ git grep -2 "com.h2database"
en/application_framework/application_framework/blank_project/CustomizeDB.rst-        <!-- Omitted -->
en/application_framework/application_framework/blank_project/CustomizeDB.rst-        <dependency>
en/application_framework/application_framework/blank_project/CustomizeDB.rst:          <groupId>com.h2database</groupId>
en/application_framework/application_framework/blank_project/CustomizeDB.rst-          <artifactId>h2</artifactId>
en/application_framework/application_framework/blank_project/CustomizeDB.rst-          <version>1.4.191</version>
--
en/application_framework/application_framework/blank_project/CustomizeDB.rst-    <!-- Omitted -->
en/application_framework/application_framework/blank_project/CustomizeDB.rst-    <dependency>
en/application_framework/application_framework/blank_project/CustomizeDB.rst:      <groupId>com.h2database</groupId>
en/application_framework/application_framework/blank_project/CustomizeDB.rst-      <artifactId>h2</artifactId>
en/application_framework/application_framework/blank_project/CustomizeDB.rst-      <version>1.4.191</version>
--
en/development_tools/toolbox/SqlExecutor/SqlExecutor.rst-      <!--使用するRDBMSにあわせて、下記JDBCドライバの dependency を更新してください。 -->
en/development_tools/toolbox/SqlExecutor/SqlExecutor.rst-      <dependency>
en/development_tools/toolbox/SqlExecutor/SqlExecutor.rst:        <groupId>com.h2database</groupId>
en/development_tools/toolbox/SqlExecutor/SqlExecutor.rst-        <artifactId>h2</artifactId>
en/development_tools/toolbox/SqlExecutor/SqlExecutor.rst-        <version>1.3.176</version>
--
ja/application_framework/application_framework/blank_project/CustomizeDB.rst-        <!-- 中略 -->
ja/application_framework/application_framework/blank_project/CustomizeDB.rst-        <dependency>
ja/application_framework/application_framework/blank_project/CustomizeDB.rst:          <groupId>com.h2database</groupId>
ja/application_framework/application_framework/blank_project/CustomizeDB.rst-          <artifactId>h2</artifactId>
ja/application_framework/application_framework/blank_project/CustomizeDB.rst-          <version>1.4.191</version>
--
ja/application_framework/application_framework/blank_project/CustomizeDB.rst-    <!-- 中略 -->
ja/application_framework/application_framework/blank_project/CustomizeDB.rst-    <dependency>
ja/application_framework/application_framework/blank_project/CustomizeDB.rst:      <groupId>com.h2database</groupId>
ja/application_framework/application_framework/blank_project/CustomizeDB.rst-      <artifactId>h2</artifactId>
ja/application_framework/application_framework/blank_project/CustomizeDB.rst-      <version>1.4.191</version>
--
ja/development_tools/toolbox/SqlExecutor/SqlExecutor.rst-      <!-- 使用するRDBMSにあわせて、下記JDBCドライバの dependency を更新してください。 -->
ja/development_tools/toolbox/SqlExecutor/SqlExecutor.rst-      <dependency>
ja/development_tools/toolbox/SqlExecutor/SqlExecutor.rst:        <groupId>com.h2database</groupId>
ja/development_tools/toolbox/SqlExecutor/SqlExecutor.rst-        <artifactId>h2</artifactId>
ja/development_tools/toolbox/SqlExecutor/SqlExecutor.rst-        <version>1.3.176</version>
```

SQLExecutor のところで引っ掛かったが、こちらは実際の実装を見るとバージョン指定は省略されていたので、ついでに解説書上のバージョン表記も省略する修正を入れた。