### PR TITLE
Nablarchのテスト環境を最新化

### DIFF
--- a/en/application_framework/application_framework/nablarch/platform.rst
+++ b/en/application_framework/application_framework/nablarch/platform.rst
@@ -42,13 +42,13 @@ Test environment of Nablarch framework
 The Nablarch framework has been tested and verified to operate properly in the following environments.
 
 Java
- * Java SE 6/8/11 [#java11]_/17 [#java17]_
+ * Java SE 6/7/8/11 [#java11]_/17 [#java17]_
 
 Database
  * Oracle Database 12c/19c/21c
  * IBM Db2 10.5/11.5
- * SQL Server 2017/2019
- * PostgreSQL 10.0/11.5/12.2/13.2/14.0
+ * SQL Server 2017/2019/2022
+ * PostgreSQL 10.0/11.5/12.2/13.2/14.0/15.2
 
 Application server
  * Oracle Weblogic Server 14.1.1

--- a/ja/application_framework/application_framework/nablarch/platform.rst
+++ b/ja/application_framework/application_framework/nablarch/platform.rst
@@ -43,13 +43,13 @@ Nablarchフレームワークのテスト環境
 Nablarchフレームワークは、以下の環境においてテストを実施し、正常に動作することを確認している。
 
 Java
- * Java SE 6/8/11 [#java11]_/17 [#java17]_
+ * Java SE 6/7/8/11 [#java11]_/17 [#java17]_
 
 データベース
  * Oracle Database 12c/19c/21c
  * IBM Db2 10.5/11.5
- * SQL Server 2017/2019
- * PostgreSQL 10.0/11.5/12.2/13.2/14.0
+ * SQL Server 2017/2019/2022
+ * PostgreSQL 10.0/11.5/12.2/13.2/14.0/15.2
 
 アプリケーションサーバ
  * Oracle Weblogic Server 14.1.1


### PR DESCRIPTION
ファイル最終行に改行がなかったためIDEで自動挿入され、差分が発生しています。
問題無いと判断（他のファイルも改行あったりなかったりなので）しましたが、問題あれば元の状態に戻します。