### PR TITLE
JSON構造化ログのstructuredMessagePrefixについて注意を追加

### DIFF
--- a/en/application_framework/application_framework/libraries/log/failure_log.rst
+++ b/en/application_framework/application_framework/libraries/log/failure_log.rst
@@ -658,8 +658,9 @@ Description rules
  
  failureLogFormatter.structuredMessagePrefix
   A marker string given at the beginning of a message to identify that the message string after formatting has been formatted into JSON format.
-  If this marker is present at the beginning of the message, :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` processes the message as JSON data.
+  If the marker string at the beginning of the message matches the marker string set in :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>`, :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` processes the message as JSON data.
   The default is ``"$JSON$"``.
+  If you change it, set the same value in :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` using LogWriter's ``structuredMessagePrefix`` property (see :ref:`log-basic_setting` for LogWriter properties).
  
 Example of the description
  .. code-block:: properties

--- a/en/application_framework/application_framework/libraries/log/http_access_log.rst
+++ b/en/application_framework/application_framework/libraries/log/http_access_log.rst
@@ -411,8 +411,9 @@ Description rules
 
  httpAccessLogFormatter.structuredMessagePrefix
   A marker string given at the beginning of a message to identify that the message string after formatting has been formatted into JSON format.
-  If this marker is present at the beginning of the message, :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` processes the message as JSON data.
+  If the marker string at the beginning of the message matches the marker string set in :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>`, :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` processes the message as JSON data.
   The default is ``"$JSON$"``.
+  If you change it, set the same value in :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` using LogWriter's ``structuredMessagePrefix`` property (see :ref:`log-basic_setting` for LogWriter properties).
 
 Example of the description
  .. code-block:: properties

--- a/en/application_framework/application_framework/libraries/log/jaxrs_access_log.rst
+++ b/en/application_framework/application_framework/libraries/log/jaxrs_access_log.rst
@@ -338,6 +338,7 @@ Description rules
   A marker string given at the beginning of a message to identify that the message string after formatting has been formatted into JSON format.
   If the marker string at the beginning of the message matches the marker string set in :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>`, :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` processes the message as JSON data.
   The default is ``"$JSON$"``.
+  If you change it, set the same value in :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` using LogWriter's ``structuredMessagePrefix`` property (see :ref:`log-basic_setting` for LogWriter properties).
 
 Example of the description
  .. code-block:: properties

--- a/en/application_framework/application_framework/libraries/log/messaging_log.rst
+++ b/en/application_framework/application_framework/libraries/log/messaging_log.rst
@@ -349,8 +349,9 @@ Description rules
 
  messagingLogFormatter.structuredMessagePrefix
   A marker string given at the beginning of a message to identify that the message string after formatting has been formatted into JSON format.
-  If this marker is present at the beginning of the message, :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` processes the message as JSON data.
+  If the marker string at the beginning of the message matches the marker string set in :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>`, :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` processes the message as JSON data.
   The default is ``"$JSON$"``.
+  If you change it, set the same value in :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` using LogWriter's ``structuredMessagePrefix`` property (see :ref:`log-basic_setting` for LogWriter properties).
 
 .. [#placeholder_json]
 
@@ -370,5 +371,3 @@ Example of the description
   # Targets for HTTP messaging
   messagingLogFormatter.httpSentMessageTargets=threadName,messageId,destination,correlationId,messageHeader,messageBody
   messagingLogFormatter.httpReceivedMessageTargets=threadName,messageId,destination,correlationId,messageHeader,messageBody
-
-

--- a/en/application_framework/application_framework/libraries/log/performance_log.rst
+++ b/en/application_framework/application_framework/libraries/log/performance_log.rst
@@ -201,8 +201,9 @@ Description rules
 
  performanceLogFormatter.structuredMessagePrefix
   A marker string given at the beginning of a message to identify that the message string after formatting has been formatted into JSON format.
-  If this marker is present at the beginning of the message, :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` processes the message as JSON data.
+  If the marker string at the beginning of the message matches the marker string set in :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>`, :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` processes the message as JSON data.
   The default is ``"$JSON$"``.
+  If you change it, set the same value in :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` using LogWriter's ``structuredMessagePrefix`` property (see :ref:`log-basic_setting` for LogWriter properties).
 
 Example of the description
  .. code-block:: properties

--- a/en/application_framework/application_framework/libraries/log/sql_log.rst
+++ b/en/application_framework/application_framework/libraries/log/sql_log.rst
@@ -437,7 +437,7 @@ Example of the description
 
   sqlLogFormatter.className=nablarch.core.db.statement.SqlJsonLogFormatter
   sqlLogFormatter.structuredMessagePrefix=$JSON$
-  sqlLogFormatter.startRetrieveTargets=methodName,sql,start,startPosition,size,additionalInfo
+  sqlLogFormatter.startRetrieveTargets=methodName,sql,startPosition,size,additionalInfo
   sqlLogFormatter.endRetrieveTargets=methodName,executeTime,retrieveTime,count
   sqlLogFormatter.startExecuteTargets=methodName,sql,additionalInfo
   sqlLogFormatter.endExecuteTargets=methodName,executeTime
@@ -446,4 +446,4 @@ Example of the description
   sqlLogFormatter.startExecuteUpdateTargets=methodName,sql,additionalInfo
   sqlLogFormatter.endExecuteUpdateTargets=methodName,executeTime,updateCount
   sqlLogFormatter.startExecuteBatchTargets=methodName,sql,additionalInfo
-  sqlLogFormatter.endExecuteBatchTargets=methodName,executeTime,updateCount
+  sqlLogFormatter.endExecuteBatchTargets=methodName,executeTime,batchCount

--- a/en/application_framework/application_framework/libraries/log/sql_log.rst
+++ b/en/application_framework/application_framework/libraries/log/sql_log.rst
@@ -428,8 +428,9 @@ Description rules
 
  sqlLogFormatter.structuredMessagePrefix
   A marker string given at the beginning of a message to identify that the message string after formatting has been formatted into JSON format.
-  If this marker is present at the beginning of the message, :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` processes the message as JSON data.
+  If the marker string at the beginning of the message matches the marker string set in :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>`, :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` processes the message as JSON data.
   The default is ``"$JSON$"``.
+  If you change it, set the same value in :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` using LogWriter's ``structuredMessagePrefix`` property (see :ref:`log-basic_setting` for LogWriter properties).
 
 Example of the description
  .. code-block:: properties

--- a/ja/application_framework/application_framework/libraries/log/failure_log.rst
+++ b/ja/application_framework/application_framework/libraries/log/failure_log.rst
@@ -664,8 +664,9 @@ JSON形式の構造化ログとして出力する
  
  failureLogFormatter.structuredMessagePrefix
   フォーマット後のメッセージ文字列が JSON 形式に整形されていることを識別できるようにするために、メッセージの先頭に付与するマーカー文字列。
-  メッセージの先頭にこのマーカーがある場合、 :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` はメッセージを JSON データとして処理する。
+  メッセージの先頭にあるマーカー文字列が :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` に設定しているマーカー文字列と一致する場合、 :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` はメッセージを JSON データとして処理する。
   デフォルトは ``"$JSON$"`` となる。
+  変更する場合は、LogWriterの ``structuredMessagePrefix`` プロパティを使用して :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` にも同じ値を設定すること（LogWriterのプロパティについては :ref:`log-basic_setting` を参照）。
  
 記述例
  .. code-block:: properties

--- a/ja/application_framework/application_framework/libraries/log/http_access_log.rst
+++ b/ja/application_framework/application_framework/libraries/log/http_access_log.rst
@@ -418,8 +418,9 @@ HTTPアクセスログの各項目もJSONの値として出力するには、
 
  httpAccessLogFormatter.structuredMessagePrefix
   フォーマット後のメッセージ文字列が JSON 形式に整形されていることを識別できるようにするために、メッセージの先頭に付与するマーカー文字列。
-  メッセージの先頭にこのマーカーがある場合、 :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` はメッセージを JSON データとして処理する。
+  メッセージの先頭にあるマーカー文字列が :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` に設定しているマーカー文字列と一致する場合、 :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` はメッセージを JSON データとして処理する。
   デフォルトは ``"$JSON$"`` となる。
+  変更する場合は、LogWriterの ``structuredMessagePrefix`` プロパティを使用して :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` にも同じ値を設定すること（LogWriterのプロパティについては :ref:`log-basic_setting` を参照）。
 
 記述例
  .. code-block:: properties

--- a/ja/application_framework/application_framework/libraries/log/jaxrs_access_log.rst
+++ b/ja/application_framework/application_framework/libraries/log/jaxrs_access_log.rst
@@ -345,6 +345,7 @@ HTTPアクセスログの各項目もJSONの値として出力するには、
   フォーマット後のメッセージ文字列が JSON 形式に整形されていることを識別できるようにするために、メッセージの先頭に付与するマーカー文字列。
   メッセージの先頭にあるマーカー文字列が :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` に設定しているマーカー文字列と一致する場合、 :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` はメッセージを JSON データとして処理する。
   デフォルトは ``"$JSON$"`` となる。
+  変更する場合は、LogWriterの ``structuredMessagePrefix`` プロパティを使用して :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` にも同じ値を設定すること（LogWriterのプロパティについては :ref:`log-basic_setting` を参照）。
 
 記述例
  .. code-block:: properties

--- a/ja/application_framework/application_framework/libraries/log/messaging_log.rst
+++ b/ja/application_framework/application_framework/libraries/log/messaging_log.rst
@@ -350,8 +350,9 @@ JSON形式の構造化ログとして出力する
 
  messagingLogFormatter.structuredMessagePrefix
   フォーマット後のメッセージ文字列が JSON 形式に整形されていることを識別できるようにするために、メッセージの先頭に付与するマーカー文字列。
-  メッセージの先頭にこのマーカーがある場合、 :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` はメッセージを JSON データとして処理する。
+  メッセージの先頭にあるマーカー文字列が :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` に設定しているマーカー文字列と一致する場合、 :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` はメッセージを JSON データとして処理する。
   デフォルトは ``"$JSON$"`` となる。
+  変更する場合は、LogWriterの ``structuredMessagePrefix`` プロパティを使用して :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` にも同じ値を設定すること（LogWriterのプロパティについては :ref:`log-basic_setting` を参照）。
 
 .. [#placeholder_json]
 
@@ -371,5 +372,3 @@ JSON形式の構造化ログとして出力する
   # HTTPメッセージング用フォーマット
   messagingLogFormatter.httpSentMessageTargets=threadName,messageId,destination,correlationId,messageHeader,messageBody
   messagingLogFormatter.httpReceivedMessageTargets=threadName,messageId,destination,correlationId,messageHeader,messageBody
-
-

--- a/ja/application_framework/application_framework/libraries/log/performance_log.rst
+++ b/ja/application_framework/application_framework/libraries/log/performance_log.rst
@@ -213,8 +213,9 @@ JSON形式の構造化ログとして出力する
 
  performanceLogFormatter.structuredMessagePrefix
   フォーマット後のメッセージ文字列が JSON 形式に整形されていることを識別できるようにするために、メッセージの先頭に付与するマーカー文字列。
-  メッセージの先頭にこのマーカーがある場合、 :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` はメッセージを JSON データとして処理する。
+  メッセージの先頭にあるマーカー文字列が :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` に設定しているマーカー文字列と一致する場合、 :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` はメッセージを JSON データとして処理する。
   デフォルトは ``"$JSON$"`` となる。
+  変更する場合は、LogWriterの ``structuredMessagePrefix`` プロパティを使用して :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` にも同じ値を設定すること（LogWriterのプロパティについては :ref:`log-basic_setting` を参照）。
 
 記述例
  .. code-block:: properties

--- a/ja/application_framework/application_framework/libraries/log/sql_log.rst
+++ b/ja/application_framework/application_framework/libraries/log/sql_log.rst
@@ -432,8 +432,9 @@ SQLログの各項目もJSONの値として出力するには、
 
  sqlLogFormatter.structuredMessagePrefix
   フォーマット後のメッセージ文字列が JSON 形式に整形されていることを識別できるようにするために、メッセージの先頭に付与するマーカー文字列。
-  メッセージの先頭にこのマーカーがある場合、 :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` はメッセージを JSON データとして処理する。
+  メッセージの先頭にあるマーカー文字列が :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` に設定しているマーカー文字列と一致する場合、 :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` はメッセージを JSON データとして処理する。
   デフォルトは ``"$JSON$"`` となる。
+  変更する場合は、LogWriterの ``structuredMessagePrefix`` プロパティを使用して :java:extdoc:`JsonLogFormatter <nablarch.core.log.basic.JsonLogFormatter>` にも同じ値を設定すること（LogWriterのプロパティについては :ref:`log-basic_setting` を参照）。
 
 記述例
  .. code-block:: properties

--- a/ja/application_framework/application_framework/libraries/log/sql_log.rst
+++ b/ja/application_framework/application_framework/libraries/log/sql_log.rst
@@ -441,7 +441,7 @@ SQLログの各項目もJSONの値として出力するには、
 
   sqlLogFormatter.className=nablarch.core.db.statement.SqlJsonLogFormatter
   sqlLogFormatter.structuredMessagePrefix=$JSON$
-  sqlLogFormatter.startRetrieveTargets=methodName,sql,start,startPosition,size,additionalInfo
+  sqlLogFormatter.startRetrieveTargets=methodName,sql,startPosition,size,additionalInfo
   sqlLogFormatter.endRetrieveTargets=methodName,executeTime,retrieveTime,count
   sqlLogFormatter.startExecuteTargets=methodName,sql,additionalInfo
   sqlLogFormatter.endExecuteTargets=methodName,executeTime
@@ -450,4 +450,4 @@ SQLログの各項目もJSONの値として出力するには、
   sqlLogFormatter.startExecuteUpdateTargets=methodName,sql,additionalInfo
   sqlLogFormatter.endExecuteUpdateTargets=methodName,executeTime,updateCount
   sqlLogFormatter.startExecuteBatchTargets=methodName,sql,additionalInfo
-  sqlLogFormatter.endExecuteBatchTargets=methodName,executeTime,updateCount
+  sqlLogFormatter.endExecuteBatchTargets=methodName,executeTime,batchCount


### PR DESCRIPTION
本題の対応に加えて、SQLログの記述例に誤りがあることが発覚したため、合わせて修正しました。