### PR TITLE
BeanUtilのレコード対応の記載を英訳しました。

### DIFF
--- a/en/application_framework/application_framework/libraries/bean_util.rst
+++ b/en/application_framework/application_framework/libraries/bean_util.rst
@@ -6,7 +6,8 @@ Bean Util
   :depth: 3
   :local:
 
-Bean Util provides the following functions related to Java Beans.
+Bean Util provides the following functions related to Java Beans. It can also handle records standardised from Java 16 in the same way as Java Beans.
+See :ref:`bean_util-use-record` for more information.
 
 * Configuring and acquiring values for properties
 * Transferring values to other Java Beans
@@ -20,6 +21,8 @@ Module list
     <groupId>com.nablarch.framework</groupId>
     <artifactId>nablarch-core-beans</artifactId>
   </dependency>
+
+.. _bean_util-use-java-beans:
 
 How to use
 --------------------------------------------------
@@ -323,3 +326,41 @@ Implementation examples
 
     // Call BeanUtil by specifying the CopyOptions.
     final DestBean copy = BeanUtil.createAndCopy(DestBean.class, bean, copyOptions);
+
+.. _bean_util-use-record:
+
+Use records in BeanUtil
+--------------------------------------------------
+
+BeanUtil can handle records standardised from Java16 in the same way as Java Beans.
+
+Note that once a record has been generated, it cannot be changed later.
+Therefore, if a record is passed as an object to be modified as an argument to methods such as
+:java:extdoc:`BeanUtil.setProperty <nablarch.core.beans.BeanUtil.setProperty(java.lang.Object-java.lang.String-java.lang.Object)>`  or :java:extdoc:`BeanUtil.copy <nablarch.core.beans.BeanUtil.copy(SRC-DEST)>` ,
+a run-time exception is raised.
+
+How to use
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Same as :ref:`operation on Java Beans <bean_util-use-java-beans>` .
+
+.. important::
+
+BeanUtil does not support records containing type parameters of type List.
+Since records cannot inherit, type parameters of type List should be set to a concrete type from the outset and records should be defined.
+
+  .. code-block:: java
+
+    public class Item implements Serializable {
+        // Property omitted.
+    }
+
+
+    // If the type parameter of List type is not set to a concrete type.
+    // Calling BeanUtil.createAndCopy(BadSampleRecord.class, map) raises a runtime exception
+    // because the type parameter of List type is not supported.
+    public class BadSampleRecord<T>(List<T> items) {}
+
+    // If the type parameter of the List type is set to a concrete type.
+    // BeanUtil.createAndCopy(GoodSampleRecord.class, map) works correctly.
+    public record GoodSampleRecord(List<Item> items) {}

--- a/en/application_framework/application_framework/libraries/bean_util.rst
+++ b/en/application_framework/application_framework/libraries/bean_util.rst
@@ -337,7 +337,7 @@ BeanUtil can handle records standardised from Java16 in the same way as Java Bea
 Note that record is an immutable class.
 Therefore, if a record is passed as an object to be modified as the argument to methods such as
 :java:extdoc:`BeanUtil.setProperty <nablarch.core.beans.BeanUtil.setProperty(java.lang.Object-java.lang.String-java.lang.Object)>`  or :java:extdoc:`BeanUtil.copy <nablarch.core.beans.BeanUtil.copy(SRC-DEST)>` ,
-a run-time exception occurs.
+a run-time exception is thrown.
 
 How to use
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/en/application_framework/application_framework/libraries/bean_util.rst
+++ b/en/application_framework/application_framework/libraries/bean_util.rst
@@ -334,7 +334,7 @@ Use records in BeanUtil
 
 BeanUtil can handle records standardised from Java16 in the same way as Java Beans.
 
-Note that once a record has been generated, it cannot be changed later.
+Note that record is an immutable class.
 Therefore, if a record is passed as an object to be modified as the argument to methods such as
 :java:extdoc:`BeanUtil.setProperty <nablarch.core.beans.BeanUtil.setProperty(java.lang.Object-java.lang.String-java.lang.Object)>`  or :java:extdoc:`BeanUtil.copy <nablarch.core.beans.BeanUtil.copy(SRC-DEST)>` ,
 a run-time exception is raised.
@@ -357,7 +357,7 @@ Same as :ref:`operation on Java Beans <bean_util-use_java_beans>` .
 
 
     // If the type parameter of List type is not set to a concrete type.
-    // Calling BeanUtil.createAndCopy(BadSampleRecord.class, map) raises a runtime exception
+    // A runtime exception occurs by calling BeanUtil.createAndCopy(BadSampleRecord.class, map)
     // because the type parameter of List type is not supported.
     public class BadSampleRecord<T>(List<T> items) {}
 

--- a/en/application_framework/application_framework/libraries/bean_util.rst
+++ b/en/application_framework/application_framework/libraries/bean_util.rst
@@ -337,7 +337,7 @@ BeanUtil can handle records standardised from Java16 in the same way as Java Bea
 Note that record is an immutable class.
 Therefore, if a record is passed as an object to be modified as the argument to methods such as
 :java:extdoc:`BeanUtil.setProperty <nablarch.core.beans.BeanUtil.setProperty(java.lang.Object-java.lang.String-java.lang.Object)>`  or :java:extdoc:`BeanUtil.copy <nablarch.core.beans.BeanUtil.copy(SRC-DEST)>` ,
-a run-time exception is raised.
+a run-time exception occurs.
 
 How to use
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -357,8 +357,9 @@ Same as :ref:`operation on Java Beans <bean_util-use_java_beans>` .
 
 
     // If the type parameter of List type is not set to a concrete type.
-    // A runtime exception occurs by calling BeanUtil.createAndCopy(BadSampleRecord.class, map)
-    // because the type parameter of List type is not supported.
+    // Calling BeanUtil.createAndCopy(BadSampleRecord.class, map)
+    // throws a runtime exception because it does not support
+    // type parameters of List type.
     public class BadSampleRecord<T>(List<T> items) {}
 
     // If the type parameter of the List type is set to a concrete type.

--- a/en/application_framework/application_framework/libraries/bean_util.rst
+++ b/en/application_framework/application_framework/libraries/bean_util.rst
@@ -335,7 +335,7 @@ Use records in BeanUtil
 BeanUtil can handle records standardised from Java16 in the same way as Java Beans.
 
 Note that once a record has been generated, it cannot be changed later.
-Therefore, if a record is passed as an object to be modified as an argument to methods such as
+Therefore, if a record is passed as an object to be modified as the argument to methods such as
 :java:extdoc:`BeanUtil.setProperty <nablarch.core.beans.BeanUtil.setProperty(java.lang.Object-java.lang.String-java.lang.Object)>`  or :java:extdoc:`BeanUtil.copy <nablarch.core.beans.BeanUtil.copy(SRC-DEST)>` ,
 a run-time exception is raised.
 
@@ -346,8 +346,8 @@ Same as :ref:`operation on Java Beans <bean_util-use_java_beans>` .
 
 .. important::
 
-BeanUtil does not support records containing type parameters of type List.
-Since records cannot inherit, type parameters of type List should be set to a concrete type from the outset and records should be defined.
+   BeanUtil does not support records containing type parameters of List type.
+   Since records cannot inherit, type parameters of List type should be set to a concrete type from the outset and records should be defined.
 
   .. code-block:: java
 

--- a/en/application_framework/application_framework/libraries/bean_util.rst
+++ b/en/application_framework/application_framework/libraries/bean_util.rst
@@ -7,7 +7,7 @@ Bean Util
   :local:
 
 Bean Util provides the following functions related to Java Beans. It can also handle records standardised from Java 16 in the same way as Java Beans.
-See :ref:`bean_util-use-record` for more information.
+See :ref:`bean_util-use_record` for more information.
 
 * Configuring and acquiring values for properties
 * Transferring values to other Java Beans
@@ -22,7 +22,7 @@ Module list
     <artifactId>nablarch-core-beans</artifactId>
   </dependency>
 
-.. _bean_util-use-java-beans:
+.. _bean_util-use_java_beans:
 
 How to use
 --------------------------------------------------
@@ -327,7 +327,7 @@ Implementation examples
     // Call BeanUtil by specifying the CopyOptions.
     final DestBean copy = BeanUtil.createAndCopy(DestBean.class, bean, copyOptions);
 
-.. _bean_util-use-record:
+.. _bean_util-use_record:
 
 Use records in BeanUtil
 --------------------------------------------------
@@ -342,7 +342,7 @@ a run-time exception is raised.
 How to use
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Same as :ref:`operation on Java Beans <bean_util-use-java-beans>` .
+Same as :ref:`operation on Java Beans <bean_util-use_java_beans>` .
 
 .. important::
 

--- a/ja/application_framework/application_framework/libraries/bean_util.rst
+++ b/ja/application_framework/application_framework/libraries/bean_util.rst
@@ -7,7 +7,7 @@ Bean Util
   :local:
 
 Java Beansに関する以下機能を提供する。また、Java16より標準化されたレコードをJava Beansと同様に取り扱うことができる。
-詳細は :ref:`bean_util-use-record` を参照。
+詳細は :ref:`bean_util-use_record` を参照。
 
 * プロパティに対する値の設定と取得
 * 他のJava Beansへの値の移送
@@ -22,7 +22,7 @@ Java Beansに関する以下機能を提供する。また、Java16より標準�
     <artifactId>nablarch-core-beans</artifactId>
   </dependency>
 
-.. _bean_util-use-java-beans:
+.. _bean_util-use_java_beans:
 
 使用方法
 --------------------------------------------------
@@ -342,7 +342,7 @@ OSSなどを用いてBeanを自動生成している場合に :ref:`プロパテ
     final DestBean copy = BeanUtil.createAndCopy(DestBean.class, bean, copyOptions);
 
 
-.. _bean_util-use-record:
+.. _bean_util-use_record:
 
 BeanUtilでレコードを使用する
 --------------------------------------------------
@@ -356,7 +356,7 @@ BeanUtilでは、Java16より標準化されたレコードをJava Beansと同�
 使用方法
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:ref:`Java Beansに対する操作 <bean_util-use-java-beans>` に準ずる。
+:ref:`Java Beansに対する操作 <bean_util-use_java_beans>` に準ずる。
 
 .. important::
 


### PR DESCRIPTION
英訳の実施と合わせ、今回追加した `:ref:` の記載がページ内の他の箇所と合っていなかったため、合わせて修正しました。
7c2f07456cc5af09b956f2a834489cc5e3803081