### PR TITLE
Micrometerのバージョンアップに伴う修正

### DIFF
--- a/ja/application_framework/adaptors/micrometer_adaptor.rst
+++ b/ja/application_framework/adaptors/micrometer_adaptor.rst
@@ -248,7 +248,7 @@ DefaultMeterBinderListProviderを廃棄処理対象にする
 また、 ``<key>`` には Micrometer がレジストリごとに提供している `設定クラス(外部サイト、英語) <https://javadoc.io/doc/io.micrometer/micrometer-core/1.13.0/io/micrometer/core/instrument/config/MeterRegistryConfig.html>`_ で定義されたメソッドと同じ名前を指定する。
 
 例えば、 `DatadogMeterRegistry(外部サイト、英語)`_ に対しては `DatadogConfig(外部サイト、英語)`_ という設定クラスが用意されている。
-そして、この設定クラスには `apyKey(外部サイト、英語) <https://javadoc.io/doc/io.micrometer/micrometer-registry-datadog/1.13.0/io/micrometer/datadog/DatadogConfig.html#apiKey()>`_ というメソッドが定義されている。
+そして、この設定クラスには `apiKey(外部サイト、英語) <https://javadoc.io/doc/io.micrometer/micrometer-registry-datadog/1.13.0/io/micrometer/datadog/DatadogConfig.html#apiKey()>`_ というメソッドが定義されている。
 
 
 
@@ -447,6 +447,10 @@ DefaultMeterBinderListProviderで収集されるメトリクス
     - JVM の起動時刻（UNIX 時間）
   * - ``jvm.gc.count``
     - GC の回数
+  * - ``jvm.threads.started``
+    - JVMで起動したスレッド数
+  * - ``process.cpu.time``
+    - Java仮想マシン・プロセスによって使用されるCPU時間
 
 実際に収集されるメトリクスのイメージは :ref:`micrometer_metrics_output_example` を参照。
 
@@ -526,7 +530,7 @@ APIキーを設定する
 
     nablarch.micrometer.datadog.apiKey=XXXXXXXXXXXXXXXX
 
-  API キーは ``nablarch.micrometer.datadog.apyKey`` で設定できる。
+  API キーは ``nablarch.micrometer.datadog.apiKey`` で設定できる。
 
   その他の設定については `DatadogConfig(外部サイト、英語)`_ を参照。
 

--- a/ja/application_framework/adaptors/micrometer_adaptor.rst
+++ b/ja/application_framework/adaptors/micrometer_adaptor.rst
@@ -771,7 +771,7 @@ OpenTelemetry Protocol (OTLP) で連携する
      * `New RelicによるOpenTelemetryの紹介(外部サイト) <https://docs.newrelic.com/jp/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction/>`_
      * `Prometheus | HTTP API | OTLP Receiver(外部サイト、英語) <https://prometheus.io/docs/prometheus/latest/querying/api/#otlp-receiver>`_
 
-ここでは、 Prometheus に OTLP で連携する場合を例にして説明する。
+ここでは、localhost の 9090 ポートで起動している Prometheus（無料で利用できるOSS）に OTLP で連携する場合を例にして説明する。
 
 依存関係を追加する
   .. code-block:: xml
@@ -794,7 +794,14 @@ OpenTelemetry Protocol (OTLP) で連携する
   .. code-block:: text
 
     # 送信先を変更
-    nablarch.micrometer.otlp.url=XXXXXXXXXXXXXXXXXXXX
+    nablarch.micrometer.otlp.url=http://localhost:9090/api/v1/otlp/v1/metrics
+
+ヘッダ情報を設定する
+  .. code-block:: text
+
+    nablarch.micrometer.otlp.headers=key1=value1,key2=value2
+
+  認証で使用するAPIキー等のヘッダ情報が必要な場合、 ``nablarch.micrometer.otlp.headers`` で設定できる。
 
 連携を無効にする
   .. code-block:: text

--- a/ja/application_framework/adaptors/micrometer_adaptor.rst
+++ b/ja/application_framework/adaptors/micrometer_adaptor.rst
@@ -771,7 +771,7 @@ OpenTelemetry Protocol (OTLP) で連携する
      * `New RelicによるOpenTelemetryの紹介(外部サイト) <https://docs.newrelic.com/jp/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction/>`_
      * `Prometheus | HTTP API | OTLP Receiver(外部サイト、英語) <https://prometheus.io/docs/prometheus/latest/querying/api/#otlp-receiver>`_
 
-ここでは、localhost の 9090 ポートで起動している Prometheus（無料で利用できるOSS）に OTLP で連携する場合を例にして説明する。
+ここでは、localhost の 9090 ポートで起動している Prometheus に OTLP で連携する場合を例にして説明する。
 
 依存関係を追加する
   .. code-block:: xml

--- a/ja/application_framework/adaptors/micrometer_adaptor.rst
+++ b/ja/application_framework/adaptors/micrometer_adaptor.rst
@@ -769,7 +769,7 @@ OpenTelemetry Protocol (OTLP) で連携する
 
      * `Datadog の OpenTelemetry(外部サイト) <https://docs.datadoghq.com/ja/opentelemetry/>`_
      * `New RelicによるOpenTelemetryの紹介(外部サイト) <https://docs.newrelic.com/jp/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction/>`_
-     * `Prometheus | HTTP API | OTLP Receiver(外部サイト) <https://prometheus.io/docs/prometheus/latest/querying/api/#otlp-receiver>`_
+     * `Prometheus | HTTP API | OTLP Receiver(外部サイト、英語) <https://prometheus.io/docs/prometheus/latest/querying/api/#otlp-receiver>`_
 
 ここでは、 Prometheus に OTLP で連携する場合を例にして説明する。
 

--- a/ja/application_framework/adaptors/micrometer_adaptor.rst
+++ b/ja/application_framework/adaptors/micrometer_adaptor.rst
@@ -792,7 +792,7 @@ OpenTelemetry はメトリクス仕様の業界標準であり、 OTLP は OpenT
   .. code-block:: text
 
     # 送信先を変更
-    nablarch.micrometer.otlp.url=http://localhost:9090/api/v1/otlp/v1/metrics
+    nablarch.micrometer.otlp.url=XXXXXXXXXXXXXXXXXXXX
 
 連携を無効にする
   .. code-block:: text

--- a/ja/application_framework/adaptors/micrometer_adaptor.rst
+++ b/ja/application_framework/adaptors/micrometer_adaptor.rst
@@ -27,12 +27,12 @@ Micrometerアダプタ
   
 .. tip::
 
-  Micrometerのバージョン1.5.4を使用してテストを行っている。
+  Micrometerのバージョン1.13.0を使用してテストを行っている。
   バージョンを変更する場合は、プロジェクト側でテストを行い問題ないことを確認すること。
 
 Micrometerアダプタを使用するための設定を行う
 --------------------------------------------------
-Micrometerでメトリクスを収集するためには、 `レジストリ(外部サイト、英語) <https://micrometer.io/docs/concepts#_registry>`_ と呼ばれるクラスを作成する必要がある。
+Micrometerでメトリクスを収集するためには、 `レジストリ(外部サイト、英語) <https://docs.micrometer.io/micrometer/reference/concepts/registry.html>`_ と呼ばれるクラスを作成する必要がある。
 本アダプタでは、このレジストリを :ref:`repository` に登録するための :java:extdoc:`ComponentFactory<nablarch.core.repository.di.ComponentFactory>` を提供している。
 
 ここでは、 `LoggingMeterRegistry(外部サイト、英語)`_ をコンポーネントとして登録する :java:extdoc:`LoggingMeterRegistryFactory<nablarch.integration.micrometer.logging.LoggingMeterRegistryFactory>` を例にして設定方法について説明する。
@@ -245,10 +245,10 @@ DefaultMeterBinderListProviderを廃棄処理対象にする
 ``OtlpMeterRegistryFactory``        ``otlp``
 =================================== ================
 
-また、 ``<key>`` には Micrometer がレジストリごとに提供している `設定クラス(外部サイト、英語) <https://javadoc.io/doc/io.micrometer/micrometer-core/1.5.4/io/micrometer/core/instrument/config/MeterRegistryConfig.html>`_ で定義されたメソッドと同じ名前を指定する。
+また、 ``<key>`` には Micrometer がレジストリごとに提供している `設定クラス(外部サイト、英語) <https://javadoc.io/doc/io.micrometer/micrometer-core/1.13.0/io/micrometer/core/instrument/config/MeterRegistryConfig.html>`_ で定義されたメソッドと同じ名前を指定する。
 
 例えば、 `DatadogMeterRegistry(外部サイト、英語)`_ に対しては `DatadogConfig(外部サイト、英語)`_ という設定クラスが用意されている。
-そして、この設定クラスには `apyKey(外部サイト、英語) <https://javadoc.io/doc/io.micrometer/micrometer-registry-datadog/1.5.4/io/micrometer/datadog/DatadogConfig.html#apiKey()>`_ というメソッドが定義されている。
+そして、この設定クラスには `apyKey(外部サイト、英語) <https://javadoc.io/doc/io.micrometer/micrometer-registry-datadog/1.13.0/io/micrometer/datadog/DatadogConfig.html#apiKey()>`_ というメソッドが定義されている。
 
 
 
@@ -510,7 +510,7 @@ Datadog と連携する
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-datadog</artifactId>
-      <version>1.5.4</version>
+      <version>1.13.0</version>
     </dependency>
 
 レジストリファクトリを宣言する
@@ -552,7 +552,7 @@ CloudWatch と連携する
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-cloudwatch2</artifactId>
-      <version>1.5.4</version>
+      <version>1.13.0</version>
     </dependency>
 
 レジストリファクトリを宣言する
@@ -653,7 +653,7 @@ MicrometerでメトリクスをAzureに連携する方法
 
   * `Azure Monitor Application Insights を監視する Java のコード不要のアプリケーション(外部サイト) <https://learn.microsoft.com/ja-jp/azure/azure-monitor/app/opentelemetry-enable?tabs=java>`_
 
-  このJava 3.0 エージェントは、Micrometerの `グローバルレジストリ(外部サイト、英語) <https://micrometer.io/docs/concepts#_global_registry>`_ に出力したメトリクスを自動的に収集し、Azureに連携する仕組みを提供している。
+  このJava 3.0 エージェントは、Micrometerの `グローバルレジストリ(外部サイト、英語) <https://docs.micrometer.io/micrometer/reference/concepts/registry.html#_global_registry>`_ に出力したメトリクスを自動的に収集し、Azureに連携する仕組みを提供している。
 
   * `アプリケーションからカスタム テレメトリを送信する(外部サイト) <https://learn.microsoft.com/ja-jp/azure/azure-monitor/app/opentelemetry-enable?tabs=java>`_
 
@@ -722,7 +722,7 @@ Datadog は `DogStatsD(外部サイト) <https://docs.datadoghq.com/ja/developer
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-statsd</artifactId>
-      <version>1.5.4</version>
+      <version>1.13.0</version>
     </dependency>
 
 レジストリファクトリを宣言する
@@ -1022,7 +1022,7 @@ SQLの処理時間
       単位はミリ秒。
 
 これらのプロパティは、Micrometerが提供する `Timer(外部サイト、英語)`_ に設定する値として使用される。
-より詳細な説明は、 `Micrometerのドキュメント <https://micrometer.io/docs/concepts#_histograms_and_percentiles>`_ を参照のこと。
+より詳細な説明は、 `Micrometerのドキュメント <https://docs.micrometer.io/micrometer/reference/concepts/histogram-quantiles.html>`_ を参照のこと。
 
 なお、これらのプロパティはデフォルトでは全て未設定のため、パーセンタイルの情報は収集されない。
 パーセンタイルの情報を収集する必要がある場合は、これらのプロパティを明示的に設定すること。
@@ -1098,8 +1098,8 @@ SQLの処理時間
 
     package example.micrometer.prometheus;
 
-    import io.micrometer.prometheus.PrometheusConfig;
-    import io.micrometer.prometheus.PrometheusMeterRegistry;
+    import io.micrometer.prometheusmetrics.PrometheusConfig;
+    import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
     import nablarch.core.repository.di.DiContainer;
     import nablarch.integration.micrometer.MeterRegistryFactory;
     import nablarch.integration.micrometer.MicrometerConfiguration;
@@ -1795,27 +1795,27 @@ Micrometerが監視サービスにメトリクスを連携する方法には、�
 
 
 
-.. _MeterBinder(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.5.4/io/micrometer/core/instrument/binder/MeterBinder.html
-.. _Counter(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.5.4/io/micrometer/core/instrument/Counter.html
-.. _Gauge(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.5.4/io/micrometer/core/instrument/Gauge.html
-.. _DatadogConfig(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-registry-datadog/1.5.4/io/micrometer/datadog/DatadogConfig.html
-.. _CloudWatchConfig(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-registry-cloudwatch2/1.5.4/io/micrometer/cloudwatch2/CloudWatchConfig.html
-.. _StatsdConfig(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-registry-statsd/1.5.4/io/micrometer/statsd/StatsdConfig.html
-.. _OtlpConfig(外部サイト、英語): https://javadoc.io/static/io.micrometer/micrometer-registry-otlp/1.9.17/io/micrometer/registry/otlp/OtlpConfig.html
-.. _MeterRegistry(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.5.4/io/micrometer/core/instrument/MeterRegistry.html
-.. _DatadogMeterRegistry(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-registry-datadog/1.5.4/io/micrometer/datadog/DatadogMeterRegistry.html
-.. _StatsdMeterRegistry(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-registry-statsd/1.5.4/io/micrometer/statsd/StatsdMeterRegistry.html
-.. _OtlpMeterRegistry(外部サイト、英語): https://javadoc.io/static/io.micrometer/micrometer-registry-otlp/1.9.17/io/micrometer/registry/otlp/OtlpMeterRegistry.html
-.. _DatadogMeterRegistry(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-registry-datadog/1.5.4/io/micrometer/datadog/DatadogMeterRegistry.html
-.. _CloudWatchMeterRegistry(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-registry-cloudwatch2/1.5.4/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.html
-.. _LoggingMeterRegistry(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.5.4/io/micrometer/core/instrument/logging/LoggingMeterRegistry.html
-.. _SimpleMeterRegistry(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.5.4/io/micrometer/core/instrument/simple/SimpleMeterRegistry.html
-.. _JvmMemoryMetrics(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.5.4/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.html 
-.. _ProcessorMetrics(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.5.4/io/micrometer/core/instrument/binder/system/ProcessorMetrics.html
-.. _JvmGcMetrics(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.5.4/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.html
-.. _JvmThreadMetrics(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.5.4/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.html
-.. _ClassLoaderMetrics(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.5.4/io/micrometer/core/instrument/binder/jvm/ClassLoaderMetrics.html
-.. _FileDescriptorMetrics(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.5.4/io/micrometer/core/instrument/binder/system/FileDescriptorMetrics.html
-.. _UptimeMetrics(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.5.4/io/micrometer/core/instrument/binder/system/UptimeMetrics.html
-.. _Timer(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.5.4/io/micrometer/core/instrument/Timer.html
-.. _PrometheusMeterRegistry(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-registry-prometheus/1.5.4/io/micrometer/prometheus/PrometheusMeterRegistry.html
+.. _MeterBinder(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.13.0/io/micrometer/core/instrument/binder/MeterBinder.html
+.. _Counter(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.13.0/io/micrometer/core/instrument/Counter.html
+.. _Gauge(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.13.0/io/micrometer/core/instrument/Gauge.html
+.. _DatadogConfig(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-registry-datadog/1.13.0/io/micrometer/datadog/DatadogConfig.html
+.. _CloudWatchConfig(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-registry-cloudwatch2/1.13.0/io/micrometer/cloudwatch2/CloudWatchConfig.html
+.. _StatsdConfig(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-registry-statsd/1.13.0/io/micrometer/statsd/StatsdConfig.html
+.. _OtlpConfig(外部サイト、英語): https://javadoc.io/static/io.micrometer/micrometer-registry-otlp/1.13.0/io/micrometer/registry/otlp/OtlpConfig.html
+.. _MeterRegistry(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.13.0/io/micrometer/core/instrument/MeterRegistry.html
+.. _DatadogMeterRegistry(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-registry-datadog/1.13.0/io/micrometer/datadog/DatadogMeterRegistry.html
+.. _StatsdMeterRegistry(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-registry-statsd/1.13.0/io/micrometer/statsd/StatsdMeterRegistry.html
+.. _OtlpMeterRegistry(外部サイト、英語): https://javadoc.io/static/io.micrometer/micrometer-registry-otlp/1.13.0/io/micrometer/registry/otlp/OtlpMeterRegistry.html
+.. _DatadogMeterRegistry(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-registry-datadog/1.13.0/io/micrometer/datadog/DatadogMeterRegistry.html
+.. _CloudWatchMeterRegistry(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-registry-cloudwatch2/1.13.0/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.html
+.. _LoggingMeterRegistry(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.13.0/io/micrometer/core/instrument/logging/LoggingMeterRegistry.html
+.. _SimpleMeterRegistry(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.13.0/io/micrometer/core/instrument/simple/SimpleMeterRegistry.html
+.. _JvmMemoryMetrics(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.13.0/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.html
+.. _ProcessorMetrics(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.13.0/io/micrometer/core/instrument/binder/system/ProcessorMetrics.html
+.. _JvmGcMetrics(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.13.0/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.html
+.. _JvmThreadMetrics(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.13.0/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.html
+.. _ClassLoaderMetrics(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.13.0/io/micrometer/core/instrument/binder/jvm/ClassLoaderMetrics.html
+.. _FileDescriptorMetrics(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.13.0/io/micrometer/core/instrument/binder/system/FileDescriptorMetrics.html
+.. _UptimeMetrics(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.13.0/io/micrometer/core/instrument/binder/system/UptimeMetrics.html
+.. _Timer(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-core/1.13.0/io/micrometer/core/instrument/Timer.html
+.. _PrometheusMeterRegistry(外部サイト、英語): https://javadoc.io/doc/io.micrometer/micrometer-registry-prometheus/1.13.0/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.html

--- a/ja/application_framework/adaptors/micrometer_adaptor.rst
+++ b/ja/application_framework/adaptors/micrometer_adaptor.rst
@@ -498,8 +498,8 @@ DefaultMeterBinderListProviderで収集されるメトリクス
 
 監視サービスと連携するためには、大きく次のとおり設定する必要がある。
 
-#. 監視サービスごとに用意された Micrometer のモジュールを依存関係に追加する
-#. 監視サービス用のレジストリファクトリをコンポーネントとして定義する
+#. 監視サービスや連携方法ごとに用意された Micrometer のモジュールを依存関係に追加する
+#. 利用するレジストリファクトリをコンポーネントとして定義する
 #. その他、監視サービスごとに独自に設定する
 
 ここでは、それぞれの監視サービスと連携する方法について説明する。
@@ -760,20 +760,18 @@ Datadog は `DogStatsD(外部サイト) <https://docs.datadoghq.com/ja/developer
 OpenTelemetry Protocol (OTLP) で連携する
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-OpenTelemetry はメトリクス仕様の業界標準であり、 OTLP は OpenTelemetry のデータ通信プロトコルである。
-``micrometer-registry-otlp`` モジュールを用いることで、さまざまなAPMサービスと連携することができる。
-
-メトリクスの連携は、エージェントまたはサービスへ直接 OTLP で送信するか、 `OpenTelemetry Collector Contrib(外部サイト) <https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main#opentelemetry-collector-contrib>`_ を介して送信することで連携できる。
-
-  * `(エージェントまたはサービスへの送信)Datadog Agent による OTLP の取り込み(外部サイト) <https://docs.datadoghq.com/ja/opentelemetry/otlp_ingest_in_the_agent/>`_
-  * `(OpenTelemetry Collector Contribに送信)OpenTelemetry Collector Datadog エクスポーター(外部サイト) <https://docs.datadoghq.com/ja/opentelemetry/otel_collector_datadog_exporter/>`_
+多くの監視サービスでは `OpenTelemetry(外部サイト、英語) <https://opentelemetry.io/>`_ をサポートしており、通信プロトコルに OpenTelemetry Protocol (以下、OTLP) を使用してメトリクスを収集することができる。
+``micrometer-registry-otlp`` モジュールを用いることで、 OTLP で様々な監視サービスと連携することができる。
 
   .. important::
-    どちらの連携方法が適しているか(または利用可能か)は、対象のサービスによって異なる。
-    また、 OpenTelemetry Collector Contrib を利用した場合、商用APMのサポート範囲は各サービスによって異なるため、サービス提供元に確認すること。
+     OpenTelemetry によるメトリクスの収集では、どういった連携方法が適しているか（利用可能か）は監視サービスによって異なるため、使用する監視サービスの情報を確認すること。
+     例として、いくつかの監視サービスの情報を以下に示す。
 
-ここでは、無料で利用できるOSSである Prometheus に OTLP で連携する場合を例にして説明する。
+     * `Datadog の OpenTelemetry(外部サイト) <https://docs.datadoghq.com/ja/opentelemetry/>`_
+     * `New RelicによるOpenTelemetryの紹介(外部サイト) <https://docs.newrelic.com/jp/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction/>`_
+     * `Prometheus | HTTP API | OTLP Receiver(外部サイト) <https://prometheus.io/docs/prometheus/latest/querying/api/#otlp-receiver>`_
 
+ここでは、 Prometheus に OTLP で連携する場合を例にして説明する。
 
 依存関係を追加する
   .. code-block:: xml


### PR DESCRIPTION
### 特記事項 (by @tishijiri )

OTLP連携の説明について、以下の観点で見直しています

- アダプタの解説書では「監視サービス」という用語を使っているため、APMサービスという言葉は使用せず「監視サービス」に統一しました
- OpenTelemetry自体の説明はNablarchの解説書でするものではないため、公式サイトへの案内のみとしました
  - StatsDと同じレベルの説明になるように考慮
  - OpenTelemetry Collector Contrib についての言及も同様の理由で除去
- 他のモジュールでは連携できない監視サービスの紹介をするのが役立つかもと思い、リンク先を見直しました
  - OpenTelemetry Collector Contribへの言及がなくなったためにDatadogのリンク先は個別ページでなくてもよいと判断し、OpenTelemetry説明TOPページに変更
  - New Relicはこの修正のきっかけとなった話でも登場していたため追加
  - Prometheusは実験機能段階のようですが、実装例で案内しているため参考にできるよう追加
  - （シェアの高さで選んでいないため、Dynatraceなどは記載していない）