### PR TITLE
Nablarchフレームワークのテスト環境にJBoss EAP 8.0を追加

### DIFF
--- a/en/application_framework/application_framework/nablarch/platform.rst
+++ b/en/application_framework/application_framework/nablarch/platform.rst
@@ -52,7 +52,7 @@ Database
 
 Application server
  * WildFly 31.0.1.Final
- * Red Hat JBoss Enterprise Application Platform 8.0.0.GA
+ * Red Hat JBoss Enterprise Application Platform 8.0.0
  * Apache Tomcat 10.1.17
 
 Jakarta EE

--- a/en/application_framework/application_framework/nablarch/platform.rst
+++ b/en/application_framework/application_framework/nablarch/platform.rst
@@ -52,6 +52,7 @@ Database
 
 Application server
  * WildFly 31.0.1.Final
+ * Red Hat JBoss Enterprise Application Platform 8.0.0.GA
  * Apache Tomcat 10.1.17
 
 Jakarta EE

--- a/ja/application_framework/application_framework/nablarch/platform.rst
+++ b/ja/application_framework/application_framework/nablarch/platform.rst
@@ -53,6 +53,7 @@ Java
 
 アプリケーションサーバ
  * WildFly 31.0.1.Final
+ * Red Hat JBoss Enterprise Application Platform 8.0.0.GA
  * Apache Tomcat 10.1.17
 
 Jakarta EE

--- a/ja/application_framework/application_framework/nablarch/platform.rst
+++ b/ja/application_framework/application_framework/nablarch/platform.rst
@@ -53,7 +53,7 @@ Java
 
 アプリケーションサーバ
  * WildFly 31.0.1.Final
- * Red Hat JBoss Enterprise Application Platform 8.0.0.GA
+ * Red Hat JBoss Enterprise Application Platform 8.0.0
  * Apache Tomcat 10.1.17
 
 Jakarta EE


### PR DESCRIPTION
# 概要

Nablarch v6のテスト環境にJBoss EAPを追加。

名称は[プロダクトページより](https://www.redhat.com/ja/technologies/jboss-middleware/application-platform)「Red Hat JBoss Enterprise Application Platform」とした。

バージョン表記については正解が不明だが起動スクリプトでのバージョン確認で表示される表記および起動時のログ出力のプロダクトバージョンを記載している。

```shell
$ bin/standalone.sh --version

JBoss EAP 8.0.0.GA (WildFly Core 21.0.5.Final-redhat-00001)
```

```shell
03:49:10,175 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: JBoss EAP 8.0.0.GA (WildFly Core 21.0.5.Final-redhat-00001) は 7690 ミリ秒で開始しました
```

### 参考

製品ドキュメントを見ると8.0 Update 02のような表記もあるようだが、製品に含まれるプロダクトバージョンとは一致しなさそうである。

https://docs.redhat.com/ja/documentation/red_hat_jboss_enterprise_application_platform/8.0/

# JIRA issue

https://nablarch.atlassian.net/browse/NAB-587