### PR TITLE
CSPに対応する場合のSubmitへの追加処理で、イベントの挙動および伝播をキャンセルするよう修正

### DIFF
--- a/ja/application_framework/application_framework/libraries/tag.rst
+++ b/ja/application_framework/application_framework/libraries/tag.rst
@@ -2744,10 +2744,11 @@ Content-Security-Policyに指定するポリシーをセキュアにしつつ、
       if (window.confirm("登録します。よろしいですか？")) {
         // カスタムタグが出力するJavaScript関数を明示的に呼び出す。
         // 第2引数のelementはnablarch_submit関数内でeventから導出する
-        return nablarch_submit(event);
+        nablarch_submit(event);
       } else {
-        // キャンセル
-        return false;
+        // submitをキャンセルする
+        event.preventDefault();
+        event.stopPropagation();
       }
     }
 


### PR DESCRIPTION
ドキュメントに記載した内容をExampleに反映して確認した際に検出。

Submitへの追加処理のサンプルを`onclick`にそのまま設定していたものを持ってきていたが、`addEventListener`で追加した場合は`return false`を行ってもイベントをキャンセルできないのでイベントの本来の挙動および伝播を明示的に止めるよう修正。

---

あまり`EventpreventDefault`や`Event#stopPropagation`を使いたく、jQueryを使うと似たようなコードを`return false`で書けるので楽だと思いますが、Nablarchの解説書でjQueryに依存するわけにもいかないのでこの例にしました。