### PR TITLE
BeanValidationのバリデーションエラー時に任意の処理を行いたい場合について記述

### DIFF
--- a/ja/application_framework/application_framework/libraries/validation/bean_validation.rst
+++ b/ja/application_framework/application_framework/libraries/validation/bean_validation.rst
@@ -719,7 +719,6 @@ Bean Validation(JSR349)の仕様では、項目名をメッセージに含める
     @OnError(type = ApplicationException.class, path = "/WEB-INF/view/project/create.jsp")
     public HttpResponse create(HttpRequest request, ExecutionContext context) {
 
-        // リクエストパラメータをBeanに変換する
         SampleForm form = BeanUtil.createAndCopy(SampleForm.class, request.getParamMap());
 
         try {

--- a/ja/application_framework/application_framework/libraries/validation/bean_validation.rst
+++ b/ja/application_framework/application_framework/libraries/validation/bean_validation.rst
@@ -786,6 +786,7 @@ APIの詳細は、 :java:extdoc:`ValidatorUtil#validateWithGroup <nablarch.core.
    ただし、Nablarchではそのような使用方法を推奨していない（ :ref:`フォームクラスは、htmlのform単位に作成する <application_design-form_html>` 及び :ref:`フォームクラスはAPI単位に作成する <rest-application_design-form_html>` を参照 ）。
    フォームクラスを共通化する目的でグループ機能を使用する場合は、プロジェクト側で十分検討の上で使用すること。
 
+
 拡張例
 ---------------
 プロジェクト固有のアノテーションとバリデーションロジックを追加したい

--- a/ja/application_framework/application_framework/libraries/validation/bean_validation.rst
+++ b/ja/application_framework/application_framework/libraries/validation/bean_validation.rst
@@ -717,24 +717,24 @@ Bean Validation(JSR349)の仕様では、項目名をメッセージに含める
   .. code-block:: java
 
     @OnError(type = ApplicationException.class, path = "/WEB-INF/view/project/create.jsp")
-        public HttpResponse create(HttpRequest request, ExecutionContext context) {
+    public HttpResponse create(HttpRequest request, ExecutionContext context) {
 
-            // リクエストパラメータをBeanに変換
-            SampleForm form = BeanUtil.createAndCopy(SampleForm.class, request.getParamMap());
+        // リクエストパラメータをBeanに変換する
+        SampleForm form = BeanUtil.createAndCopy(SampleForm.class, request.getParamMap());
 
-            try {
-                // BeanValidation実行
-                ValidatorUtil.validate(form);
-            } catch (ApplicationException e) {
-                // バリデーションエラー時に必要な処理
-                // ...
+        try {
+            // バリデーションを明示的に実行する
+            ValidatorUtil.validate(form);
+        } catch (ApplicationException e) {
+            // バリデーションエラー時に任意の処理を行う
+            // ...
 
-                // 例外ApplicationExceptionを送出し、@OnErrorアノテーションで指定された遷移先に遷移
-                throw new ApplicationException(e.getMessages());
-            }
-
-            // 以下省略
+            // ApplicationExceptionを送出し、@OnErrorアノテーションで指定された遷移先に遷移する
+            throw new ApplicationException(e.getMessages());
         }
+
+        // 以下省略
+    }
 
 
 .. _bean_validation-use_groups:

--- a/ja/application_framework/application_framework/libraries/validation/bean_validation.rst
+++ b/ja/application_framework/application_framework/libraries/validation/bean_validation.rst
@@ -704,12 +704,12 @@ Bean Validation(JSR349)の仕様では、項目名をメッセージに含める
 
 バリデーションエラー時に任意の処理を行いたい
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-通常、Webアプリケーションでは :java:extdoc:`InjectForm <nablarch.common.web.interceptor.InjectForm>` アノテーション、RESTfulウェブサービスでは :java:extdoc:`Valid <javax.validation.Valid>` アノテーションを設定することで、リソース(アクション)のメソッドで受け取るForm(Bean)に対して、バリデーションが自動で行われる。
+通常、バリデーションは `ウェブアプリケーションのユーザ入力値のチェックを行う`_ や `RESTfulウェブサービスのユーザ入力値のチェックを行う`_ で案内している方法で行う。
 
-しかし、バリデーションエラー時にも任意の処理を行う必要がある場合、 これらでは処理を記述する箇所がない。（バリデーションエラー時は、アクションまで処理が来ないため。）
+しかし、この方法でバリデーションを行った場合、バリデーションエラー時に任意の処理を行うことができない。
 
-バリデーションエラー時に任意の処理を行いたい場合には、明示的にバリデーションを実行することで自由に例外ハンドリングを行うことができる。
-明示的にバリデーションを実行するには :java:extdoc:`ValidatorUtil#validate <nablarch.core.validation.ee.ValidatorUtil.validate(java.lang.Object-java.lang.Class...)>` を使用すること。
+バリデーションエラー時に任意の処理を行いたい場合には、明示的にバリデーションを実行することでバリデーションエラー時に発生する例外をハンドリングできるため、任意の処理を行うことができる。
+明示的にバリデーションを実行するには :java:extdoc:`ValidatorUtil#validate <nablarch.core.validation.ee.ValidatorUtil.validate(java.lang.Object-java.lang.Class...)>` を使用する。
 
 以下に実装例を示す。
 


### PR DESCRIPTION
システム開発ガイドあった、[バリデーションを任意のタイミングで実行してエラーハンドリングする方法を説明しているページ](https://github.com/Fintan-contents/nablarch-system-development-guide/blob/master/%E3%82%B5%E3%83%B3%E3%83%97%E3%83%AB%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88/%E3%82%B5%E3%83%B3%E3%83%97%E3%83%AB%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E9%96%8B%E7%99%BA%E3%82%AC%E3%82%A4%E3%83%89/PGUT%E5%B7%A5%E7%A8%8B/pg/%E3%83%90%E3%83%AA%E3%83%87%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%92%E4%BB%BB%E6%84%8F%E3%81%AE%E3%82%BF%E3%82%A4%E3%83%9F%E3%83%B3%E3%82%B0%E3%81%A7%E8%A1%8C%E3%81%86%E5%AE%9F%E8%A3%85%E6%96%B9%E6%B3%95%EF%BC%88Web%EF%BC%89.md) はNablarch本体の解説書で案内すべき内容だったため追記。

独自の実装からNablarch提供のValidatorUtilを使用した方法に変更した。