### PR TITLE
BeanValidationのバリデーションエラー時に任意の処理を行いたい場合について記述で、request.getParamMap()がアーキ向けのため説明を修正（英）

### DIFF
--- a/en/application_framework/application_framework/libraries/validation/bean_validation.rst
+++ b/en/application_framework/application_framework/libraries/validation/bean_validation.rst
@@ -701,6 +701,81 @@ Generated Message
   To change the method of adding the item name to the message, see :java:extdoc:`ItemNamedConstraintViolationConverterFactory <nablarch.core.validation.ee.ItemNamedConstraintViolationConverterFactory>`
   and add the implementation on the project side.
 
+.. _bean_validation-execute_explicitly:
+
+Performing Explicit Execution of Validation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Normally, validation is using the methods described in `Checking User Input Values for Web Applications`_ or `Checking User Input Values for RESTful Web Services`_ ,  but there are cases where these methods cannot be used, such as when you want to handle validation errors.
+
+In such cases, :java:extdoc:`ValidatorUtil#validate <nablarch.core.validation.ee.ValidatorUtil.validate(java.lang.Object-java.lang.Class...)>` can be used to explicitly perform validation.
+
+  .. code-block:: java
+
+    // Perform explicit execution of validation
+    ValidatorUtil.validate(form);
+
+If a validation error occurs, :java:extdoc:`ApplicationException <nablarch.core.message.ApplicationException>` is thrown.
+
+For web applications
+    When explicitly performing validation in a web application, the input values contained in the request parameters must be converted to beans.
+
+    In order to convert to bean, it is necessary to obtain the request parameters from :java:extdoc:`HttpRequest#getParamMap <nablarch.fw.web.HttpRequest.getParamMap()>`  before validation.
+    However, if the application programmer can freely handle the input values before validation, the business logic will be executed without validation, and in some cases there is a risk of failure.
+
+    For this reason, :java:extdoc:`HttpRequest#getParamMap <nablarch.fw.web.HttpRequest.getParamMap()>` to obtain request parameters is a public API for architects, and its use in the Action class is prohibited.
+
+    If a web application needs to explicitly perform validation, it is recommended to create the following utility classes as common parts.
+
+    .. code-block:: java
+
+        public final class ProjectValidatorUtil {
+            // Other processes are omitted
+
+            /**
+             * Generate beans from HTTP request and perform bean validation.
+             *
+             * @param beanClass Bean class you want to generate
+             * @param request HTTP request
+             * @return  Bean object with registered values for properties
+             */
+            public static <T> T getValidatedBean(Class<T> beanClass, HttpRequest request) {
+                T bean = BeanUtil.createAndCopy(beanClass, request.getParamMap());
+                ValidatorUtil.validate(bean);
+                return bean;
+            }
+        }
+
+
+.. _bean_validation-execute:
+
+Perform optional processing when there is a validation error
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If you want to perform optional processing when there is a validation error, you can explicitly validate to handle the exception that occurs when there is a validation error.
+
+The following is an example implementation using the utility class in the `Performing Explicit Execution of Validation`_ implementation example.
+
+Implementation examples
+  .. code-block:: java
+
+    @OnError(type = ApplicationException.class, path = "/WEB-INF/view/project/create.jsp")
+    public HttpResponse create(HttpRequest request, ExecutionContext context) {
+
+        final ProjectForm form;
+
+        try {
+            // Explicitly perform validation and retrieve validated form
+            form = ProjectValidatorUtil.getValidatedBean(ProjectForm.class, request);
+        } catch (ApplicationException e) {
+            // Perform optional processing when there is a validation error
+            // ...
+
+            // Throws an ApplicationException and transitions to the destination specified by the @OnError annotation.
+            throw new ApplicationException(e.getMessages());
+        }
+
+        // Omitted
+    }
+
 
 .. _bean_validation-use_groups:
 

--- a/en/application_framework/application_framework/libraries/validation/bean_validation.rst
+++ b/en/application_framework/application_framework/libraries/validation/bean_validation.rst
@@ -738,7 +738,7 @@ For web applications
              * @param request HTTP request
              * @return  Bean object with registered values for properties
              */
-            public static <T> T getValidatedBean(Class<T> beanClass, HttpRequest request) {
+            public static <T> T validate(Class<T> beanClass, HttpRequest request) {
                 T bean = BeanUtil.createAndCopy(beanClass, request.getParamMap());
                 ValidatorUtil.validate(bean);
                 return bean;
@@ -760,11 +760,11 @@ Implementation examples
     @OnError(type = ApplicationException.class, path = "/WEB-INF/view/project/create.jsp")
     public HttpResponse create(HttpRequest request, ExecutionContext context) {
 
-        final ProjectForm form;
+        ProjectForm form;
 
         try {
             // Explicitly perform validation and retrieve validated form
-            form = ProjectValidatorUtil.getValidatedBean(ProjectForm.class, request);
+            form = ProjectValidatorUtil.validate(ProjectForm.class, request);
         } catch (ApplicationException e) {
             // Perform optional processing when there is a validation error
             // ...

--- a/ja/application_framework/application_framework/libraries/validation/bean_validation.rst
+++ b/ja/application_framework/application_framework/libraries/validation/bean_validation.rst
@@ -735,10 +735,12 @@ Webアプリケーションの場合
          *
          * @param beanClass 生成したいBeanクラス
          * @param request HTTPリクエスト
+         * @return  プロパティに値が登録されたBeanオブジェクト
          */
-        public void validate(Class<T> beanClass, HttpRequest request) {
+        public static <T> T getValidatedBean(Class<T> beanClass, HttpRequest request) {
             T bean = BeanUtil.createAndCopy(beanClass, request.getParamMap());
             ValidatorUtil.validate(bean);
+            return bean;
         }
     }
 
@@ -756,9 +758,12 @@ Webアプリケーションの場合
 
     @OnError(type = ApplicationException.class, path = "/WEB-INF/view/project/create.jsp")
     public HttpResponse create(HttpRequest request, ExecutionContext context) {
+
+        final ProjectForm form;
+
         try {
-            // バリデーションを明示的に実行する
-            ProjectValidatorUtil.validate(Project.class, request);
+            // バリデーションを明示的に実行し、バリデーション済みのフォームを取得する
+            form = ProjectValidatorUtil.getValidatedBean(ProjectForm.class, request);
         } catch (ApplicationException e) {
             // バリデーションエラー時に任意の処理を行う
             // ...

--- a/ja/application_framework/application_framework/libraries/validation/bean_validation.rst
+++ b/ja/application_framework/application_framework/libraries/validation/bean_validation.rst
@@ -737,7 +737,7 @@ Webアプリケーションの場合
          * @param request HTTPリクエスト
          * @return  プロパティに値が登録されたBeanオブジェクト
          */
-        public static <T> T getValidatedBean(Class<T> beanClass, HttpRequest request) {
+        public static <T> T validate(Class<T> beanClass, HttpRequest request) {
             T bean = BeanUtil.createAndCopy(beanClass, request.getParamMap());
             ValidatorUtil.validate(bean);
             return bean;
@@ -759,11 +759,11 @@ Webアプリケーションの場合
     @OnError(type = ApplicationException.class, path = "/WEB-INF/view/project/create.jsp")
     public HttpResponse create(HttpRequest request, ExecutionContext context) {
 
-        final ProjectForm form;
+        ProjectForm form;
 
         try {
             // バリデーションを明示的に実行し、バリデーション済みのフォームを取得する
-            form = ProjectValidatorUtil.getValidatedBean(ProjectForm.class, request);
+            form = ProjectValidatorUtil.validate(ProjectForm.class, request);
         } catch (ApplicationException e) {
             // バリデーションエラー時に任意の処理を行う
             // ...


### PR DESCRIPTION
- https://github.com/nablarch/nablarch-document/pull/615 の英語版対応　https://github.com/nablarch/nablarch-document/commit/d2fe42eb484ec557fc5bd8b75c587b8df5d10fef
- ユーティリティクラスの実装例で、Beanを返すように修正https://github.com/nablarch/nablarch-document/commit/79251a85f94a3456e9285255c539ecdd77e3dcbf