### PR TITLE
nablarch-toolboxへの不要なリンクを削除

### DIFF
--- a/en/development_tools/toolbox/index.rst
+++ b/en/development_tools/toolbox/index.rst
@@ -13,7 +13,6 @@ Useful Tools When Developing Applications
 .. _nablarchToolBoxPage:
 
 This document introduces tools that are useful for developing applications. |br|
-`Source code <https://github.com/nablarch/nablarch-toolbox>`_
 
 
 .. list-table::

--- a/ja/development_tools/toolbox/index.rst
+++ b/ja/development_tools/toolbox/index.rst
@@ -13,7 +13,6 @@
 .. _nablarchToolBoxPage:
 
 本書では、アプリケーション開発時に使える便利なツールを紹介する。|br|
-`ソースコード <https://github.com/nablarch/nablarch-toolbox>`_
 
 
 .. list-table::


### PR DESCRIPTION
6系では業務画面JSP検証ツールを提供しないため、 https://github.com/nablarch/nablarch-toolbox/pull/20 を実施した。
合わせて[解説書](https://nablarch.github.io/docs/6-LATEST/doc/development_tools/toolbox/index.html)で案内しているnablarch-toolboxへのリンクの削除も必要だったが、対応できていなかったため、本PRでリンクの削除を実施した。