### PR TITLE
Doma2外部サイトへの案内のリンクの表示が不揃いだったため統一

### DIFF
--- a/ja/application_framework/adaptors/doma_adaptor.rst
+++ b/ja/application_framework/adaptors/doma_adaptor.rst
@@ -41,7 +41,7 @@ Domaアダプタを使用するための設定を行う
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 以下を参考にプロジェクトの依存関係を設定する必要がある。
 
-詳細は `Doma(外部サイト) <https://doma.readthedocs.io/ja/latest/build/#build-with-maven>`_ を参照。
+詳細は `Doma2(外部サイト) <https://doma.readthedocs.io/ja/latest/build/#build-with-maven>`_ を参照。
 
 .. code-block:: xml
 


### PR DESCRIPTION
Doma2外部サイトへのリンクの表示が同じURLにもも関わらず、`Doma(外部サイト)`と`Doma2(外部サイト)`のように不揃いだったので統一しました。

