### PR TITLE
リンク説明中の「JSP」を「Jakarta Server Pages」に修正

### DIFF
--- a/ja/examples/index.rst
+++ b/ja/examples/index.rst
@@ -45,7 +45,7 @@ Exampleの一覧
 ウェブアプリケーション
 ----------------------
 
-- `ウェブアプリケーション (JSP) <https://github.com/nablarch/nablarch-example-web>`_ (:ref:`解説 <getting_started>`)
+- `ウェブアプリケーション (Jakarta Server Pages) <https://github.com/nablarch/nablarch-example-web>`_ (:ref:`解説 <getting_started>`)
 - `ウェブアプリケーション (Thymeleaf) <https://github.com/nablarch/nablarch-example-thymeleaf-web>`_ (:ref:`解説 <web_thymeleaf_adaptor>`)
 
 


### PR DESCRIPTION
#623 の修正で、Nablarch 6前提の記載に「JSP」の文言を入れてしまっていたので、「Jakarta Server Pages」に修正。
#623 の修正内容を見直し、他に同様の箇所がないことは確認済み。