### PR TITLE
ビルド時の警告に対応

### DIFF
--- a/en/application_framework/adaptors/doma_adaptor.rst
+++ b/en/application_framework/adaptors/doma_adaptor.rst
@@ -40,7 +40,7 @@ Configure dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 You need to set the project dependencies by referring to the following.
 
-For details, see `Doma(external site) <https://doma.readthedocs.io/en/latest/build/#build-with-maven>`_ .
+For details, see `Maven build configuration in Doma2(external site) <https://doma.readthedocs.io/en/latest/build/#build-with-maven>`_ .
 
 .. code-block:: xml
 

--- a/en/examples/05/index.rst
+++ b/en/examples/05/index.rst
@@ -136,6 +136,7 @@ The file management ID is stored along with the file in the file management tabl
 .. important::
  A sequence is required for numbering.
  A sequence with the same name as the fileIdKey specified in the component configuration file described below must be created in advance.
+
 ---------------------------
 How to Use
 ---------------------------

--- a/ja/application_framework/adaptors/doma_adaptor.rst
+++ b/ja/application_framework/adaptors/doma_adaptor.rst
@@ -41,7 +41,7 @@ Domaアダプタを使用するための設定を行う
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 以下を参考にプロジェクトの依存関係を設定する必要がある。
 
-詳細は `Doma2(外部サイト) <https://doma.readthedocs.io/ja/latest/build/#build-with-maven>`_ を参照。
+詳細は `Doma2でのMavenビルド設定(外部サイト) <https://doma.readthedocs.io/ja/latest/build/#build-with-maven>`_ を参照。
 
 .. code-block:: xml
 


### PR DESCRIPTION
以下2件の警告に対応した。

- ac23ce46042548d61664de7016156366bb668f4c Doma2のリンク文字列が重複していることにより警告が発生してたので、一方のリンク文字列を変更（日・英）
- bf7dcfed349f9129d87db1b6952dc41a636bed98 見出しの前に空行がないことにより警告が発生していたので、空行を追加（英のみ）

合わせて、日本語Doma2ページの末尾に改行がなかったため、追加した。