### PR TITLE
ブランクプロジェクトのJettyを用いた実行手順で、不要なモノを削除し補足を追記

### DIFF
--- a/en/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
@@ -159,14 +159,7 @@ If the current directory is not yet moved to the generated project, move the dir
 
   cd myapp-web
 
-Execute the following command to build the web application.
-
-.. code-block:: text
-
-  mvn compile
-
-
-Execute the following command to start the application for communication confirmation on the web module.
+Execute the following command to build the application for communication confirmation and then start it.
 
 .. code-block:: text
 
@@ -175,6 +168,7 @@ Execute the following command to start the application for communication confirm
 .. tip::
 
   "jetty:run" of Maven used in the above command example is a specification to use the run goal of the Jetty Maven Plugin.
+  The compile goal, which builds the application, is executed in conjunction with “jetty:run” and does not need to be explicitly executed.
 
   For information on the Jetty Maven Plugin, see `Jetty Maven Plugin (external site) <https://jetty.org/docs/jetty/12/programming-guide/maven-jetty/jetty-maven-plugin.html>`_.
 

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/setup_WebService.rst
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/setup_WebService.rst
@@ -182,14 +182,7 @@ If the current directory is not yet moved to the generated project, move the dir
 
   cd myapp-jaxrs
 
-Execute the following command to build the RESTful web service.
-
-.. code-block:: text
-
-  mvn compile
-
-
-Execute the following command to start the application for communication confirmation of RESTful web service.
+Execute the following command to build the application for communication confirmation and then start it.
 
 .. code-block:: text
 
@@ -198,6 +191,7 @@ Execute the following command to start the application for communication confirm
 .. tip::
 
   "jetty:run" of Maven used in the above command example is a specification to use the run goal of the Jetty Maven Plugin.
+  The compile goal, which builds the application, is executed in conjunction with “jetty:run” and does not need to be explicitly executed.
 
   For information on the Jetty Maven Plugin, see `Jetty Maven Plugin (external site) <https://jetty.org/docs/jetty/12/programming-guide/maven-jetty/jetty-maven-plugin.html>`_.
 

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
@@ -159,14 +159,7 @@ package      パッケージ(通常はグループIDと同じ)       ``com.examp
 
   cd myapp-web
 
-次に、以下のコマンドを実行し、ウェブアプリケーションをビルドする。
-
-.. code-block:: text
-
-  mvn compile
-
-
-その後、以下のコマンドを実行することで、モジュールwebで疎通確認用のアプリケーションを起動する。
+次に、以下のコマンドを実行し、ウェブアプリケーションをビルドし、モジュールwebで疎通確認用のアプリケーションを起動する。
 
 .. code-block:: text
 
@@ -175,6 +168,7 @@ package      パッケージ(通常はグループIDと同じ)       ``com.examp
 .. tip::
 
   上記のコマンド例で使用しているMavenの「jetty:run」は、 Jetty Maven Pluginのrunゴールを使用するという指定である。
+  アプリケーションのビルドを行うcompileゴールは「jetty:run」で合わせて実行されるため、明示的に実行する手順は不要である。
   
   Jetty Maven Pluginについては `Jetty Maven Plugin(外部サイト、英語) <https://jetty.org/docs/jetty/12/programming-guide/maven-jetty/jetty-maven-plugin.html>`_  を参照。
 

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
@@ -159,7 +159,7 @@ package      パッケージ(通常はグループIDと同じ)       ``com.examp
 
   cd myapp-web
 
-次に、以下のコマンドを実行し、ウェブアプリケーションをビルドし、モジュールwebで疎通確認用のアプリケーションを起動する。
+その後、以下のコマンドを実行することで、疎通確認用のアプリケーションをビルドしてから起動する。
 
 .. code-block:: text
 
@@ -168,7 +168,7 @@ package      パッケージ(通常はグループIDと同じ)       ``com.examp
 .. tip::
 
   上記のコマンド例で使用しているMavenの「jetty:run」は、 Jetty Maven Pluginのrunゴールを使用するという指定である。
-  アプリケーションのビルドを行うcompileゴールは「jetty:run」で合わせて実行されるため、明示的に実行する手順は不要である。
+  アプリケーションのビルドを行うcompileゴールは「jetty:run」で合わせて実行されるため、明示的に実行する必要はない。
   
   Jetty Maven Pluginについては `Jetty Maven Plugin(外部サイト、英語) <https://jetty.org/docs/jetty/12/programming-guide/maven-jetty/jetty-maven-plugin.html>`_  を参照。
 

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_WebService.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_WebService.rst
@@ -182,7 +182,7 @@ package      パッケージ(通常はグループIDと同じ)       ``com.examp
 
   cd myapp-jaxrs
 
-次に、以下のコマンドを実行することで、RESTfulウェブサービスをビルドし、疎通確認用のアプリケーションを起動する。
+その後、以下のコマンドを実行することで、疎通確認用のアプリケーションをビルドしてから起動する。
 
 .. code-block:: text
 
@@ -191,7 +191,7 @@ package      パッケージ(通常はグループIDと同じ)       ``com.examp
 .. tip::
 
   上記のコマンド例で使用しているMavenの「jetty:run」は、 Jetty Maven Pluginのrunゴールを使用するという指定である。
-  アプリケーションのビルドを行うcompileゴールは「jetty:run」で合わせて実行されるため、明示的に実行する手順は不要である。
+  アプリケーションのビルドを行うcompileゴールは「jetty:run」で合わせて実行されるため、明示的に実行する必要はない。
 
   Jetty Maven Pluginについては `Jetty Maven Plugin(外部サイト、英語) <https://jetty.org/docs/jetty/12/programming-guide/maven-jetty/jetty-maven-plugin.html>`_  を参照。
 

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_WebService.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_WebService.rst
@@ -182,14 +182,7 @@ package      パッケージ(通常はグループIDと同じ)       ``com.examp
 
   cd myapp-jaxrs
 
-次に、以下のコマンドを実行し、RESTfulウェブサービスをビルドする。
-
-.. code-block:: text
-
-  mvn compile
-
-
-その後、以下のコマンドを実行することで、RESTfulウェブサービスの疎通確認用のアプリケーションを起動する。
+次に、以下のコマンドを実行することで、RESTfulウェブサービスをビルドし、疎通確認用のアプリケーションを起動する。
 
 .. code-block:: text
 
@@ -198,7 +191,8 @@ package      パッケージ(通常はグループIDと同じ)       ``com.examp
 .. tip::
 
   上記のコマンド例で使用しているMavenの「jetty:run」は、 Jetty Maven Pluginのrunゴールを使用するという指定である。
-  
+  アプリケーションのビルドを行うcompileゴールは「jetty:run」で合わせて実行されるため、明示的に実行する手順は不要である。
+
   Jetty Maven Pluginについては `Jetty Maven Plugin(外部サイト、英語) <https://jetty.org/docs/jetty/12/programming-guide/maven-jetty/jetty-maven-plugin.html>`_  を参照。
 
 


### PR DESCRIPTION
 Readmeに手順として記載されていた以下の手順は、明示的に実行する必要がないため削除しました。

- `comile`
`jetty:run`を実行する際に`compile`も合わせて実行されるため不要。