### PR TITLE
英語記事のFintanのリンクを修正

### DIFF
--- a/en/external_contents/index.rst
+++ b/en/external_contents/index.rst
@@ -22,7 +22,7 @@ Before starting a full-scale project, it is recommended to read through Nablarch
 
 For more information, see the following links.
 
- | `Nablarch System Development Guide (external site) <https://fintan.jp/page/252/>`__
+ | `Nablarch System Development Guide (external site) <https://fintan.jp/en/page/1667/>`__
 
 
 .. _development_standards:

--- a/en/external_contents/index.rst
+++ b/en/external_contents/index.rst
@@ -37,4 +37,4 @@ Since it contains many documents that are useful for quality improvement and uni
 
 The list of contents provided as development standards can be found at the following link.
 
- | `Development Standards (external site) <https://fintan.jp/en/page/1658/>`__
+ | `Development Standards (external site) <https://fintan.jp/en/page/1954/#development-standards>`__

--- a/en/index.rst
+++ b/en/index.rst
@@ -56,7 +56,7 @@ Nablarch development tool
 Useful content for development in Nablarch
 -----------------------------------------------
 
-:doc:`Useful contents for development in Nablarch are introduced <external_contents/index>`, which are available on `Fintan (external site)  <https://fintan.jp/en/page/1954/>`_.
+:doc:`Useful contents for development in Nablarch are introduced <external_contents/index>`, which are available on `Fintan (external site)  <https://fintan.jp/en/>`_.
 
  | :ref:`system_development_guide`
  | :ref:`development_standards`

--- a/ja/index.rst
+++ b/ja/index.rst
@@ -58,7 +58,7 @@ Nablarch開発ツール
 Nablarchでの開発に役立つコンテンツ
 -----------------------------------------------
 
-`Fintan(外部サイト) <https://fintan.jp/page/1868/>`_ で公開している、Nablarchでの開発に役立つ :doc:`コンテンツを紹介 <external_contents/index>` しています。
+`Fintan(外部サイト) <https://fintan.jp/>`_ で公開している、Nablarchでの開発に役立つ :doc:`コンテンツを紹介 <external_contents/index>` しています。
 
  | :ref:`system_development_guide`
  | :ref:`development_standards`


### PR DESCRIPTION
- システム開発ガイドへのリンクが日本語記事のものになっていたため、修正した。
- 開発標準へのリンクが、「Nablarchとは？」ページの「Development Standards」セクションを向いていなかったので、修正した。
  - 当該リンクは、2024/9/30に有効になる予定。