### PR TITLE
ブランクプロジェクトの作成で、バッチファイルの提供ではなくコマンドを案内する形に修正（v5）

### DIFF
--- a/en/application_framework/application_framework/blank_project/MavenModuleStructures/index.rst
+++ b/en/application_framework/application_framework/blank_project/MavenModuleStructures/index.rst
@@ -38,6 +38,8 @@ Nablarch offers the following archetypes: All the archetype group IDs are ``com.
     - Docker container edition of the ``nablarch-jaxrs-archetype`` archetype
   * - nablarch-container-batch-archetype
     - Docker container edition of the ``nablarch-batch-archetype`` archetype
+  * - nablarch-container-batch-dbless-archetype
+    - Docker container edition of the ``nablarch-batch-dbless-archetype`` archetype
 
 When ``pj-web``, ``pj-batch`` are specified respectively in ``artifactId``,
 which is input during the project creation using nablarch-web-archetype and nablarch-batch-archetype archetypes, the configuration is as follows.
@@ -92,6 +94,8 @@ As in the case of pj-web and pj-batch above, the details of each component will 
     - nablarch-container-jaxrs-archetype
   * - pj-container-batch
     - nablarch-container-batch-archetype
+  * - pj-container-batch-dbless
+    - nablarch-container-batch-dbless-archetype
 
 .. _about_maven_parent_module:
 
@@ -485,6 +489,8 @@ pj-container-batch project
 
 Project to build a Docker image of a Linux Server where the Nablarch batch applications is deployed.
 
+.. _firstStepContainerBatchProjectStructure:
+
 Project structure
 ------------------
 
@@ -530,7 +536,17 @@ Project structure
     |           \---data
     |
     \---work
-                
+
+pj-container-batch-dbless project
+========================================
+
+Project to build a Docker image of a Linux Server where the Nablarch dbless batch applications is deployed.
+
+Project structure
+------------------
+
+Omitted because the DB-related directory and files are excluded from :ref:`pj-container-batch project structure <firstStepContainerBatchProjectStructure>` .
+
 .. _about_maven_web_batch_module:
 
 Common configurations for each project

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/bat/generateJbatchProject.bat
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/bat/generateJbatchProject.bat
@@ -1,7 +1,0 @@
-if "%5" EQU "" (
-  set package=%2
-) else (
-  set package=%5
-)
-
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DinteractiveMode=false -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-ee-archetype -DarchetypeVersion=%1 -DgroupId=%2 -DartifactId=%3 -Dversion=%4 -Dpackage=%package%

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/bat/generateNablarchBatchDblessProject.bat
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/bat/generateNablarchBatchDblessProject.bat
@@ -1,7 +1,0 @@
-if "%5" EQU "" (
-  set package=%2
-) else (
-  set package=%5
-)
-
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DinteractiveMode=false -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-dbless-archetype -DarchetypeVersion=%1 -DgroupId=%2 -DartifactId=%3 -Dversion=%4 -Dpackage=%package%

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/bat/generateNablarchBatchProject.bat
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/bat/generateNablarchBatchProject.bat
@@ -1,7 +1,0 @@
-if "%5" EQU "" (
-  set package=%2
-) else (
-  set package=%5
-)
-
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DinteractiveMode=false -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-archetype -DarchetypeVersion=%1 -DgroupId=%2 -DartifactId=%3 -Dversion=%4 -Dpackage=%package%

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/bat/generateWebProject.bat
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/bat/generateWebProject.bat
@@ -1,7 +1,0 @@
-if "%5" EQU "" (
-  set package=%2
-) else (
-  set package=%5
-)
-
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DinteractiveMode=false -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=%1 -DgroupId=%2 -DartifactId=%3 -Dversion=%4 -Dpackage=%package%

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/bat/generateWebServiceProject.bat
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/bat/generateWebServiceProject.bat
@@ -1,7 +1,0 @@
-if "%5" EQU "" (
-  set package=%2
-) else (
-  set package=%5
-)
-
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DinteractiveMode=false -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-jaxrs-archetype -DarchetypeVersion=%1 -DgroupId=%2 -DartifactId=%3 -Dversion=%4 -Dpackage=%package%

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/setup_Jbatch.rst
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/setup_Jbatch.rst
@@ -63,7 +63,7 @@ Execute the following command.
 
   mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-ee-archetype -DarchetypeVersion={nablarch_version}
 
-The version of nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
+The version of Nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
 
 .. list-table::
   :header-rows: 1

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/setup_Jbatch.rst
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/setup_Jbatch.rst
@@ -53,16 +53,41 @@ Generate a blank project using the archetypes provided by Nablarch.
 Execute the mvn command
 -------------------------------------------------------
 
-Change the current directory to the directory where the blank project (can be any directory) is to be created, and place the following file.
+Use `Maven Archetype Plugin(external site) <https://maven.apache.org/archetype/maven-archetype-plugin/usage.html>`_ to generate a blank project.
 
-:download:`Batch file <bat/generateJbatchProject.bat>`
+Change the current directory to the directory where the blank project (can be any directory) is to be created.
 
-After placing the file, specify the necessary parameters in the arguments and execute the bat file.
+Execute the following command.
 
-generateJbatchProject.bat |nablarch_version| <<groupId>> <<artifactId>> <<version>> <<package(optional)>>
+.. code-block:: bat
 
-The parameters configured in the above command are as follows.
-If you want to change the version of Nablarch, change |nablarch_version|.
+  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-ee-archetype -DarchetypeVersion={nablarch_version}
+
+The version of nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
+
+.. list-table::
+  :header-rows: 1
+  :class: white-space-normal
+  :widths: 6,20
+
+  * - Set value
+    - Description
+  * - archetypeVersion
+    - Specify the version of the archetype you wish to use. (Nablarch 5u25 or later must be specified)
+
+.. tip::
+  If you want to generate blank projects with Nablarch 5u24 or earlier, change ``archetype:generate`` to ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` in the above command and execute as in the following example.
+
+  .. code-block:: bat
+
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
+
+  The version of Nablarch used in this example is 5u24. If you want to change the version, change the parameter archetypeVersion in the same way.
+
+Enter project information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the above command is executed, you will be asked to enter the following information about the blank project to be generated.
 
 =========== ================================================= =======================
 Input item  Description                                       Configuration example
@@ -76,6 +101,11 @@ package      Package (normally the same as group ID)          ``com.example``
 .. important::
    Item groupId and package are mapped to the Java package name.
    Use lowercase letters, numbers, and dots for these input values, and do not use hyphens.
+
+When you have finished entering project information, Y: : will appear.
+
+ * Enter 「Y」 if you want to generate a template based on the information you have entered.
+ * Enter 「N」 if you wish to redo the project information entry.
 
 If the command ends normally, a blank project is created under the current directory.
 

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/setup_Jbatch.rst
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/setup_Jbatch.rst
@@ -80,7 +80,7 @@ The version of Nablarch used in the above command is |nablarch_version|. If you 
 
   .. code-block:: bat
 
-    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-ee-archetype -DarchetypeVersion=5u24
 
   The version of Nablarch used in this example is 5u24. If you want to change the version, change the parameter archetypeVersion in the same way.
 

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/setup_NablarchBatch.rst
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/setup_NablarchBatch.rst
@@ -56,17 +56,41 @@ Generate a blank project using the archetypes provided by Nablarch.
 Execute the mvn command
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Change the current directory to the directory where the blank project (can be any directory) is to be created, and place the following file.
+Use `Maven Archetype Plugin(external site) <https://maven.apache.org/archetype/maven-archetype-plugin/usage.html>`_ to generate a blank project.
 
-:download:`Batch file <bat/generateNablarchBatchProject.bat>`
-
-After placing the file, specify the necessary parameters in the arguments and execute the bat file.
-
-generateNablarchBatchProject.bat |nablarch_version| <<groupId>> <<artifactId>> <<version>> <<package(optional)>>
-
-The parameters configured in the above command are as follows.
-If you want to change the version of Nablarch, change |nablarch_version|.
 Change the current directory to the directory where the blank project (can be any directory) is to be created.
+
+Execute the following command.
+
+.. code-block:: bat
+
+  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-archetype -DarchetypeVersion={nablarch_version}
+
+The version of nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
+
+.. list-table::
+  :header-rows: 1
+  :class: white-space-normal
+  :widths: 6,20
+
+  * - Set value
+    - Description
+  * - archetypeVersion
+    - Specify the version of the archetype you wish to use. (Nablarch 5u25 or later must be specified)
+
+.. tip::
+  If you want to generate blank projects with Nablarch 5u24 or earlier, change ``archetype:generate`` to ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` in the above command and execute as in the following example.
+
+  .. code-block:: bat
+
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
+
+  The version of Nablarch used in this example is 5u24. If you want to change the version, change the parameter archetypeVersion in the same way.
+
+Enter project information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the above command is executed, you will be asked to enter the following information about the blank project to be generated.
 
 =========== ================================================= =======================
 Input item  Description                                       Configuration example
@@ -80,6 +104,11 @@ package      Package (normally the same as group ID)          ``com.example``
 .. important::
    Item groupId and package are mapped to the Java package name.
    Use lowercase letters, numbers, and dots for these input values, and do not use hyphens.
+
+When you have finished entering project information, Y: : will appear.
+
+ * Enter 「Y」 if you want to generate a template based on the information you have entered.
+ * Enter 「N」 if you wish to redo the project information entry.
 
 If the command ends normally, a blank project is created under the current directory.
 

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/setup_NablarchBatch.rst
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/setup_NablarchBatch.rst
@@ -83,7 +83,7 @@ The version of Nablarch used in the above command is |nablarch_version|. If you 
 
   .. code-block:: bat
 
-    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-archetype -DarchetypeVersion=5u24
 
   The version of Nablarch used in this example is 5u24. If you want to change the version, change the parameter archetypeVersion in the same way.
 

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/setup_NablarchBatch.rst
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/setup_NablarchBatch.rst
@@ -66,7 +66,7 @@ Execute the following command.
 
   mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-archetype -DarchetypeVersion={nablarch_version}
 
-The version of nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
+The version of Nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
 
 .. list-table::
   :header-rows: 1

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/setup_NablarchBatch_Dbless.rst
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/setup_NablarchBatch_Dbless.rst
@@ -46,17 +46,41 @@ Generate a blank project using the archetypes provided by Nablarch.
 Execute the mvn command
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Change the current directory to the directory where the blank project (can be any directory) is to be created, and place the following file.
+Use `Maven Archetype Plugin(external site) <https://maven.apache.org/archetype/maven-archetype-plugin/usage.html>`_ to generate a blank project.
 
-:download:`Batch file <bat/generateNablarchBatchDblessProject.bat>`
-
-After placing the file, specify the necessary parameters in the arguments and execute the bat file.
-
-generateNablarchBatchDblessProject.bat |nablarch_version| <<groupId>> <<artifactId>> <<version>> <<package(optional)>>
-
-The parameters configured in the above command are as follows.
-If you want to change the version of Nablarch, change |nablarch_version|.
 Change the current directory to the directory where the blank project (can be any directory) is to be created.
+
+Execute the following command.
+
+.. code-block:: bat
+
+  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-dbless-archetype -DarchetypeVersion={nablarch_version}
+
+The version of nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
+
+.. list-table::
+  :header-rows: 1
+  :class: white-space-normal
+  :widths: 6,20
+
+  * - Set value
+    - Description
+  * - archetypeVersion
+    - Specify the version of the archetype you wish to use. (Nablarch 5u25 or later must be specified)
+
+.. tip::
+  If you want to generate blank projects with Nablarch 5u24 or earlier, change ``archetype:generate`` to ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` in the above command and execute as in the following example.
+
+  .. code-block:: bat
+
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
+
+  The version of Nablarch used in this example is 5u24. If you want to change the version, change the parameter archetypeVersion in the same way.
+
+Enter project information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the above command is executed, you will be asked to enter the following information about the blank project to be generated.
 
 =========== ================================================= =======================
 Input item  Description                                       Configuration example
@@ -70,6 +94,11 @@ package      Package (normally the same as group ID)          ``com.example``
 .. important::
    Item groupId and package are mapped to the Java package name.
    Use lowercase letters, numbers, and dots for these input values, and do not use hyphens.
+
+When you have finished entering project information, Y: : will appear.
+
+ * Enter 「Y」 if you want to generate a template based on the information you have entered.
+ * Enter 「N」 if you wish to redo the project information entry.
 
 If the command ends normally, a blank project is created under the current directory.
 

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/setup_NablarchBatch_Dbless.rst
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/setup_NablarchBatch_Dbless.rst
@@ -56,7 +56,7 @@ Execute the following command.
 
   mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-dbless-archetype -DarchetypeVersion={nablarch_version}
 
-The version of nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
+The version of Nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
 
 .. list-table::
   :header-rows: 1

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/setup_NablarchBatch_Dbless.rst
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/setup_NablarchBatch_Dbless.rst
@@ -73,7 +73,7 @@ The version of Nablarch used in the above command is |nablarch_version|. If you 
 
   .. code-block:: bat
 
-    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-dbless-archetype -DarchetypeVersion=5u24
 
   The version of Nablarch used in this example is 5u24. If you want to change the version, change the parameter archetypeVersion in the same way.
 

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
@@ -59,7 +59,7 @@ Execute the following command.
 
   mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion={nablarch_version}
 
-The version of nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
+The version of Nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
 
 .. list-table::
   :header-rows: 1

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
@@ -51,16 +51,39 @@ Execute the mvn command
 
 Use `Maven Archetype Plugin(external site) <https://maven.apache.org/archetype/maven-archetype-plugin/usage.html>`_ to generate a blank project.
 
-Change the current directory to the directory where the blank project (can be any directory) is to be created, and place the following file.
+Change the current directory to the directory where the blank project (can be any directory) is to be created.
 
-:download:`Batch file <bat/generateWebProject.bat>`
+Execute the following command.
 
-After placing the file, specify the necessary parameters in the arguments and execute the bat file.
+.. code-block:: bat
 
-generateWebProject.bat |nablarch_version| <<groupId>> <<artifactId>> <<version>> <<package(optional)>>
+  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion={nablarch_version}
 
-The parameters configured in the above command are as follows.
-To change the version of nablarch, change |nablarch_version|.
+The version of nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
+
+.. list-table::
+  :header-rows: 1
+  :class: white-space-normal
+  :widths: 6,20
+
+  * - Set value
+    - Description
+  * - archetypeVersion
+    - Specify the version of the archetype you wish to use. (Nablarch 5u25 or later must be specified)
+
+.. tip::
+  If you want to generate blank projects with Nablarch 5u24 or earlier, change ``archetype:generate`` to ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` in the above command and execute as in the following example.
+
+  .. code-block:: bat
+
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
+
+  The version of Nablarch used in this example is 5u24. If you want to change the version, change the parameter archetypeVersion in the same way.
+
+Enter project information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the above command is executed, you will be asked to enter the following information about the blank project to be generated.
 
 =========== ================================================= =======================
 Input item  Description                                       Configuration example
@@ -74,6 +97,11 @@ package      Package (normally the same as group ID)          ``com.example``
 .. important::
    Item groupId and package are mapped to the Java package name.
    Use lowercase letters, numbers, and dots for these input values, and do not use hyphens.
+
+When you have finished entering project information, Y: : will appear.
+
+ * Enter 「Y」 if you want to generate a template based on the information you have entered.
+ * Enter 「N」 if you wish to redo the project information entry.
 
 If the command ends normally, a blank project is created under the current directory.
 

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/setup_WebService.rst
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/setup_WebService.rst
@@ -88,7 +88,7 @@ The version of Nablarch used in the above command is |nablarch_version|. If you 
 
   .. code-block:: bat
 
-    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-jaxrs-archetype -DarchetypeVersion=5u24
 
   The version of Nablarch used in this example is 5u24. If you want to change the version, change the parameter archetypeVersion in the same way.
 

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/setup_WebService.rst
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/setup_WebService.rst
@@ -71,7 +71,7 @@ Execute the following command.
 
   mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-jaxrs-archetype -DarchetypeVersion={nablarch_version}
 
-The version of nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
+The version of Nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
 
 .. list-table::
   :header-rows: 1

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/setup_WebService.rst
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/setup_WebService.rst
@@ -63,16 +63,39 @@ Execute the mvn command
 
 Use `Maven Archetype Plugin(external site) <https://maven.apache.org/archetype/maven-archetype-plugin/usage.html>`_ to generate a blank project.
 
-Change the current directory to the directory where the blank project (can be any directory) is to be created, and place the following file.
+Change the current directory to the directory where the blank project (can be any directory) is to be created.
 
-:download:`Batch file <bat/generateWebServiceProject.bat>`
+Execute the following command.
 
-After placing the file, specify the necessary parameters in the arguments and execute the bat file.
+.. code-block:: bat
 
-generateWebServiceProject.bat |nablarch_version| <<groupId>> <<artifactId>> <<version>> <<package(optional)>>
+  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-jaxrs-archetype -DarchetypeVersion={nablarch_version}
 
-The parameters configured in the above command are as follows.
-If you want to change the version of Nablarch, change |nablarch_version|.
+The version of nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
+
+.. list-table::
+  :header-rows: 1
+  :class: white-space-normal
+  :widths: 6,20
+
+  * - Set value
+    - Description
+  * - archetypeVersion
+    - Specify the version of the archetype you wish to use. (Nablarch 5u25 or later must be specified)
+
+.. tip::
+  If you want to generate blank projects with Nablarch 5u24 or earlier, change ``archetype:generate`` to ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` in the above command and execute as in the following example.
+
+  .. code-block:: bat
+
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
+
+  The version of Nablarch used in this example is 5u24. If you want to change the version, change the parameter archetypeVersion in the same way.
+
+Enter project information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the above command is executed, you will be asked to enter the following information about the blank project to be generated.
 
 =========== ================================================= =======================
 Input item  Description                                       Configuration example
@@ -87,6 +110,10 @@ package      Package (normally the same as group ID)          ``com.example``
    Item groupId and package are mapped to the Java package name.
    Use lowercase letters, numbers, and dots for these input values, and do not use hyphens.
 
+When you have finished entering project information, Y: : will appear.
+
+ * Enter 「Y」 if you want to generate a template based on the information you have entered.
+ * Enter 「N」 if you wish to redo the project information entry.
 
 If the command ends normally, a blank project is created under the current directory.
 

--- a/en/application_framework/application_framework/blank_project/setup_containerBlankProject/bat/generateContainerNablarchBatchDblessProject.bat
+++ b/en/application_framework/application_framework/blank_project/setup_containerBlankProject/bat/generateContainerNablarchBatchDblessProject.bat
@@ -1,7 +1,0 @@
-if "%5" EQU "" (
-  set package=%2
-) else (
-  set package=%5
-)
-
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DinteractiveMode=false -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-dbless-archetype -DarchetypeVersion=%1 -DgroupId=%2 -DartifactId=%3 -Dversion=%4 -Dpackage=%package%

--- a/en/application_framework/application_framework/blank_project/setup_containerBlankProject/bat/generateContainerNablarchBatchProject.bat
+++ b/en/application_framework/application_framework/blank_project/setup_containerBlankProject/bat/generateContainerNablarchBatchProject.bat
@@ -1,7 +1,0 @@
-if "%5" EQU "" (
-  set package=%2
-) else (
-  set package=%5
-)
-
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DinteractiveMode=false -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-archetype -DarchetypeVersion=%1 -DgroupId=%2 -DartifactId=%3 -Dversion=%4 -Dpackage=%package%

--- a/en/application_framework/application_framework/blank_project/setup_containerBlankProject/bat/generateContainerWebProject.bat
+++ b/en/application_framework/application_framework/blank_project/setup_containerBlankProject/bat/generateContainerWebProject.bat
@@ -1,7 +1,0 @@
-if "%5" EQU "" (
-  set package=%2
-) else (
-  set package=%5
-)
-
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DinteractiveMode=false -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-web-archetype -DarchetypeVersion=%1 -DgroupId=%2 -DartifactId=%3 -Dversion=%4 -Dpackage=%package%

--- a/en/application_framework/application_framework/blank_project/setup_containerBlankProject/bat/generateContainerWebServiceProject.bat
+++ b/en/application_framework/application_framework/blank_project/setup_containerBlankProject/bat/generateContainerWebServiceProject.bat
@@ -1,7 +1,0 @@
-if "%5" EQU "" (
-  set package=%2
-) else (
-  set package=%5
-)
-
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DinteractiveMode=false -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-jaxrs-archetype -DarchetypeVersion=%1 -DgroupId=%2 -DartifactId=%3 -Dversion=%4 -Dpackage=%package%

--- a/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerBatch.rst
+++ b/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerBatch.rst
@@ -66,7 +66,7 @@ Execute the following command.
 
   mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-archetype -DarchetypeVersion={nablarch_version}
 
-The version of nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
+The version of Nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
 
 .. list-table::
   :header-rows: 1

--- a/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerBatch.rst
+++ b/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerBatch.rst
@@ -83,7 +83,7 @@ The version of Nablarch used in the above command is |nablarch_version|. If you 
 
   .. code-block:: bat
 
-    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-archetype -DarchetypeVersion=5u24
 
   The version of Nablarch used in this example is 5u24. If you want to change the version, change the parameter archetypeVersion in the same way.
 

--- a/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerBatch.rst
+++ b/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerBatch.rst
@@ -58,17 +58,39 @@ Execute the mvn command
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Use `Maven Archetype Plugin(external site) <https://maven.apache.org/archetype/maven-archetype-plugin/usage.html>`_ to generate a blank project.
 
-Change the current directory to the directory where the blank project (can be any directory) is to be created, and place the following file.
-
-:download:`Batch file <bat/generateContainerNablarchBatchProject.bat>`
-
-After placing the file, specify the necessary parameters in the arguments and execute the bat file.
-
-generateContainerNablarchBatchProject.bat |nablarch_version| <<groupId>> <<artifactId>> <<version>> <<package(optional)>>
-
-The parameters configured in the above command are as follows.
-If you want to change the version of Nablarch, change |nablarch_version|.
 Change the current directory to the directory where the blank project (can be any directory) is to be created.
+
+Execute the following command.
+
+.. code-block:: bat
+
+  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-archetype -DarchetypeVersion={nablarch_version}
+
+The version of nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
+
+.. list-table::
+  :header-rows: 1
+  :class: white-space-normal
+  :widths: 6,20
+
+  * - Set value
+    - Description
+  * - archetypeVersion
+    - Specify the version of the archetype you wish to use. (Nablarch 5u25 or later must be specified)
+
+.. tip::
+  If you want to generate blank projects with Nablarch 5u24 or earlier, change ``archetype:generate`` to ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` in the above command and execute as in the following example.
+
+  .. code-block:: bat
+
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
+
+  The version of Nablarch used in this example is 5u24. If you want to change the version, change the parameter archetypeVersion in the same way.
+
+Enter project information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the above command is executed, you will be asked to enter the following information about the blank project to be generated.
 
 =========== ================================================= =======================
 Input item  Description                                       Configuration example
@@ -82,6 +104,11 @@ package      Package (normally the same as group ID)          ``com.example``
 .. important::
    Item groupId and package are mapped to the Java package name.
    Use lowercase letters, numbers, and dots for these input values, and do not use hyphens.
+
+When you have finished entering project information, Y: : will appear.
+
+ * Enter 「Y」 if you want to generate a template based on the information you have entered.
+ * Enter 「N」 if you wish to redo the project information entry.
 
 If the command ends normally, a blank project is created under the current directory.
 

--- a/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerBatch_Dbless.rst
+++ b/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerBatch_Dbless.rst
@@ -56,7 +56,7 @@ Execute the following command.
 
   mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-dbless-archetype -DarchetypeVersion={nablarch_version}
 
-The version of nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
+The version of Nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
 
 .. list-table::
   :header-rows: 1

--- a/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerBatch_Dbless.rst
+++ b/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerBatch_Dbless.rst
@@ -73,7 +73,7 @@ The version of Nablarch used in the above command is |nablarch_version|. If you 
 
   .. code-block:: bat
 
-    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-dbless-archetype -DarchetypeVersion=5u24
 
   The version of Nablarch used in this example is 5u24. If you want to change the version, change the parameter archetypeVersion in the same way.
 

--- a/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerBatch_Dbless.rst
+++ b/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerBatch_Dbless.rst
@@ -48,17 +48,39 @@ Execute the mvn command
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Use `Maven Archetype Plugin(external site) <https://maven.apache.org/archetype/maven-archetype-plugin/usage.html>`_ to generate a blank project.
 
-Change the current directory to the directory where the blank project (can be any directory) is to be created, and place the following file.
-
-:download:`Batch file <bat/generateContainerNablarchBatchDblessProject.bat>`
-
-After placing the file, specify the necessary parameters in the arguments and execute the bat file.
-
-generateContainerNablarchBatchDblessProject.bat |nablarch_version| <<groupId>> <<artifactId>> <<version>> <<package(optional)>>
-
-The parameters configured in the above command are as follows.
-If you want to change the version of Nablarch, change |nablarch_version|.
 Change the current directory to the directory where the blank project (can be any directory) is to be created.
+
+Execute the following command.
+
+.. code-block:: bat
+
+  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-dbless-archetype -DarchetypeVersion={nablarch_version}
+
+The version of nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
+
+.. list-table::
+  :header-rows: 1
+  :class: white-space-normal
+  :widths: 6,20
+
+  * - Set value
+    - Description
+  * - archetypeVersion
+    - Specify the version of the archetype you wish to use. (Nablarch 5u25 or later must be specified)
+
+.. tip::
+  If you want to generate blank projects with Nablarch 5u24 or earlier, change ``archetype:generate`` to ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` in the above command and execute as in the following example.
+
+  .. code-block:: bat
+
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
+
+  The version of Nablarch used in this example is 5u24. If you want to change the version, change the parameter archetypeVersion in the same way.
+
+Enter project information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the above command is executed, you will be asked to enter the following information about the blank project to be generated.
 
 =========== ================================================= =======================
 Input item  Description                                       Configuration example
@@ -72,6 +94,11 @@ package      Package (normally the same as group ID)          ``com.example``
 .. important::
    Item groupId and package are mapped to the Java package name.
    Use lowercase letters, numbers, and dots for these input values, and do not use hyphens.
+
+When you have finished entering project information, Y: : will appear.
+
+ * Enter 「Y」 if you want to generate a template based on the information you have entered.
+ * Enter 「N」 if you wish to redo the project information entry.
 
 If the command ends normally, a blank project is created under the current directory.
 

--- a/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerWeb.rst
+++ b/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerWeb.rst
@@ -53,16 +53,39 @@ Execute the mvn command
 
 Use `Maven Archetype Plugin(external site) <https://maven.apache.org/archetype/maven-archetype-plugin/usage.html>`_ to generate a blank project.
 
-Change the current directory to the directory where the blank project (can be any directory) is to be created, and place the following file.
+Change the current directory to the directory where the blank project (can be any directory) is to be created.
 
-:download:`Batch file <bat/generateContainerWebProject.bat>`
+Execute the following command.
 
-After placing the file, specify the necessary parameters in the arguments and execute the bat file.
+.. code-block:: bat
 
-generateContainerWebProject.bat |nablarch_version| <<groupId>> <<artifactId>> <<version>> <<package(optional)>>
+  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-web-archetype -DarchetypeVersion={nablarch_version}
 
-The parameters to be set in the above command are as follows.
-If you want to change the version of nablarch, change |nablarch_version| .
+The version of nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
+
+.. list-table::
+  :header-rows: 1
+  :class: white-space-normal
+  :widths: 6,20
+
+  * - Set value
+    - Description
+  * - archetypeVersion
+    - Specify the version of the archetype you wish to use. (Nablarch 5u25 or later must be specified)
+
+.. tip::
+  If you want to generate blank projects with Nablarch 5u24 or earlier, change ``archetype:generate`` to ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` in the above command and execute as in the following example.
+
+  .. code-block:: bat
+
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
+
+  The version of Nablarch used in this example is 5u24. If you want to change the version, change the parameter archetypeVersion in the same way.
+
+Enter project information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the above command is executed, you will be asked to enter the following information about the blank project to be generated.
 
 =========== ================================================= =======================
 Input item  Description                                       Configuration example
@@ -76,6 +99,11 @@ package      Package (normally the same as group ID)          ``com.example``
 .. important::
    Item groupId and package are mapped to the Java package name.
    Use lowercase letters, numbers, and dots for these input values, and do not use hyphens.
+
+When you have finished entering project information, Y: : will appear.
+
+ * Enter 「Y」 if you want to generate a template based on the information you have entered.
+ * Enter 「N」 if you wish to redo the project information entry.
 
 If the command ends normally, a blank project is created under the current directory.
 

--- a/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerWeb.rst
+++ b/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerWeb.rst
@@ -78,7 +78,7 @@ The version of Nablarch used in the above command is |nablarch_version|. If you 
 
   .. code-block:: bat
 
-    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-web-archetype -DarchetypeVersion=5u24
 
   The version of Nablarch used in this example is 5u24. If you want to change the version, change the parameter archetypeVersion in the same way.
 

--- a/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerWeb.rst
+++ b/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerWeb.rst
@@ -61,7 +61,7 @@ Execute the following command.
 
   mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-web-archetype -DarchetypeVersion={nablarch_version}
 
-The version of nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
+The version of Nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
 
 .. list-table::
   :header-rows: 1

--- a/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerWebService.rst
+++ b/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerWebService.rst
@@ -91,7 +91,7 @@ The version of Nablarch used in the above command is |nablarch_version|. If you 
 
   .. code-block:: bat
 
-    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-jaxrs-archetype -DarchetypeVersion=5u24
 
   The version of Nablarch used in this example is 5u24. If you want to change the version, change the parameter archetypeVersion in the same way.
 

--- a/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerWebService.rst
+++ b/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerWebService.rst
@@ -74,7 +74,7 @@ Execute the following command.
 
   mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-jaxrs-archetype -DarchetypeVersion={nablarch_version}
 
-The version of nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
+The version of Nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
 
 .. list-table::
   :header-rows: 1

--- a/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerWebService.rst
+++ b/en/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerWebService.rst
@@ -66,16 +66,39 @@ Execute the mvn command
 
 Use `Maven Archetype Plugin(external site) <https://maven.apache.org/archetype/maven-archetype-plugin/usage.html>`_ to generate a blank project.
 
-Change the current directory to the directory where the blank project (can be any directory) is to be created, and place the following file.
+Change the current directory to the directory where the blank project (can be any directory) is to be created.
 
-:download:`Batch file <bat/generateContainerWebServiceProject.bat>`
+Execute the following command.
 
-After placing the file, specify the necessary parameters in the arguments and execute the bat file.
+.. code-block:: bat
 
-generateContainerWebServiceProject.bat |nablarch_version| <<groupId>> <<artifactId>> <<version>> <<package(optional)>>
+  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-jaxrs-archetype -DarchetypeVersion={nablarch_version}
 
-The parameters configured in the above command are as follows.
-If you want to change the version of Nablarch, change |nablarch_version|.
+The version of nablarch used in the above command is |nablarch_version|. If you want to change the version, change the following parameters.
+
+.. list-table::
+  :header-rows: 1
+  :class: white-space-normal
+  :widths: 6,20
+
+  * - Set value
+    - Description
+  * - archetypeVersion
+    - Specify the version of the archetype you wish to use. (Nablarch 5u25 or later must be specified)
+
+.. tip::
+  If you want to generate blank projects with Nablarch 5u24 or earlier, change ``archetype:generate`` to ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` in the above command and execute as in the following example.
+
+  .. code-block:: bat
+
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
+
+  The version of Nablarch used in this example is 5u24. If you want to change the version, change the parameter archetypeVersion in the same way.
+
+Enter project information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the above command is executed, you will be asked to enter the following information about the blank project to be generated.
 
 =========== ================================================= =========================
 Input item  Description                                       Configuration example
@@ -90,6 +113,10 @@ package      Package (normally the same as group ID)          ``com.example``
    Item groupId and package are mapped to the Java package name.
    Use lowercase letters, numbers, and dots for these input values, and do not use hyphens.
 
+When you have finished entering project information, Y: : will appear.
+
+ * Enter 「Y」 if you want to generate a template based on the information you have entered.
+ * Enter 「N」 if you wish to redo the project information entry.
 
 If the command ends normally, a blank project is created under the current directory.
 

--- a/en/conf.py
+++ b/en/conf.py
@@ -316,11 +316,32 @@ javadoc_url_map = {
   'javax.ws' : ('https://docs.oracle.com/javaee/7/api/', 'javadoc8')
 }
 
-# add custom javascript
-def setup(app):
-  app.add_javascript('custom.js')
-  
 rst_prolog= u".. |nablarch_version| replace:: " + version + """
 """
 
 extlinks = {'javadoc_url' : ('https://nablarch.github.io/docs/' + version + '/publishedApi/%s', 'path')}
+
+# Sphinx の拡張機能を設定するための関数
+def setup(app):
+   # カスタムのjavascriptファイルを追加する。
+   app.add_javascript('custom.js')
+
+   # Sphinxの設定に辞書replacements_for_source_readを追加する。
+   app.add_config_value('replacements_for_source_read', {}, True)
+   # Sphinxがドキュメントのソースコードを読み込んだ際にイベントハンドラを呼び出すように設定する。
+   app.connect('source-read', replace_in_document_sources)
+
+# code-blockではrst_prologで定義した変数展開が行えないため、ドキュメントのソースコードをSphinxが読み取る際に文字列置換することでcode-block内で疑似的に変数展開を行うために導入する関数
+# source-readイベントで呼び出されるように登録し、辞書replacements_for_source_readに登録されているキーと値に文字列置換を行う。
+# ドキュメント内の文字列を辞書replacements_for_source_readで登録した内容で単純に文字列置換するため、辞書のキーに登録した文字列をそのまま表示できなくなることに注意すること。
+def replace_in_document_sources(app, docname, source):
+    result = source[0]
+    for key in app.config.replacements_for_source_read:
+        result = result.replace(key, app.config.replacements_for_source_read[key])
+    source[0] = result
+
+# 登録されたキーと値がソースコードを読み込む際に文字列置換される辞書
+# 辞書のキーに登録した文字列をそのまま表示できなくなるリスクがあるので、現状使用箇所がなく、|nablarch_version|に表記が近い{nabalrch_version}を定義している。
+replacements_for_source_read = {
+    "{nablarch_version}" : version
+}

--- a/ja/application_framework/application_framework/blank_project/MavenModuleStructures/index.rst
+++ b/ja/application_framework/application_framework/blank_project/MavenModuleStructures/index.rst
@@ -38,6 +38,8 @@ Nablarchでは、以下のアーキタイプを提供している。なお、ア
     - ``nablarch-jaxrs-archetype`` のDockerコンテナ版アーキタイプ
   * - nablarch-container-batch-archetype
     - ``nablarch-batch-archetype`` のDockerコンテナ版アーキタイプ
+  * - nablarch-container-batch-dbless-archetype
+    - ``nablarch-batch-dbless-archetype`` のDockerコンテナ版アーキタイプ
 
 
 
@@ -95,6 +97,8 @@ nablarch-web-archetypeとnablarch-batch-archetypeのアーキタイプを使用�
     - nablarch-container-jaxrs-archetype
   * - pj-container-batch
     - nablarch-container-batch-archetype
+  * - pj-container-batch-dbless
+    - nablarch-container-batch-dbless-archetype
 
 
 .. _about_maven_parent_module:
@@ -491,6 +495,8 @@ pj-container-batchプロジェクト
 
 NablarchバッチアプリケーションがデプロイされたLinuxサーバのDockerイメージをビルドするプロジェクト。
 
+.. _firstStepContainerBatchProjectStructure:
+
 プロジェクトの構成
 ------------------
 
@@ -536,6 +542,16 @@ NablarchバッチアプリケーションがデプロイされたLinuxサーバ�
     |           \---data
     |
     \---work
+
+pj-container-batch-dblessプロジェクト
+========================================
+
+DBに接続しないNablarchバッチアプリケーションがデプロイされたLinuxサーバのDockerイメージをビルドするプロジェクト。
+
+プロジェクトの構成
+------------------
+
+:ref:`pj-container-batchプロジェクトの構成 <firstStepContainerBatchProjectStructure>` からDB関連のディレクトリ及びファイルを除いただけであるため省略。
 
 .. _about_maven_web_batch_module:
 

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/bat/generateJbatchProject.bat
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/bat/generateJbatchProject.bat
@@ -1,7 +1,0 @@
-if "%5" EQU "" (
-  set package=%2
-) else (
-  set package=%5
-)
-
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DinteractiveMode=false -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-ee-archetype -DarchetypeVersion=%1 -DgroupId=%2 -DartifactId=%3 -Dversion=%4 -Dpackage=%package%

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/bat/generateNablarchBatchDblessProject.bat
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/bat/generateNablarchBatchDblessProject.bat
@@ -1,7 +1,0 @@
-if "%5" EQU "" (
-  set package=%2
-) else (
-  set package=%5
-)
-
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DinteractiveMode=false -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-dbless-archetype -DarchetypeVersion=%1 -DgroupId=%2 -DartifactId=%3 -Dversion=%4 -Dpackage=%package%

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/bat/generateNablarchBatchProject.bat
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/bat/generateNablarchBatchProject.bat
@@ -1,7 +1,0 @@
-if "%5" EQU "" (
-  set package=%2
-) else (
-  set package=%5
-)
-
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DinteractiveMode=false -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-archetype -DarchetypeVersion=%1 -DgroupId=%2 -DartifactId=%3 -Dversion=%4 -Dpackage=%package%

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/bat/generateWebProject.bat
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/bat/generateWebProject.bat
@@ -1,7 +1,0 @@
-if "%5" EQU "" (
-  set package=%2
-) else (
-  set package=%5
-)
-
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DinteractiveMode=false -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=%1 -DgroupId=%2 -DartifactId=%3 -Dversion=%4 -Dpackage=%package%

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/bat/generateWebServiceProject.bat
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/bat/generateWebServiceProject.bat
@@ -1,7 +1,0 @@
-if "%5" EQU "" (
-  set package=%2
-) else (
-  set package=%5
-)
-
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DinteractiveMode=false -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-jaxrs-archetype -DarchetypeVersion=%1 -DgroupId=%2 -DartifactId=%3 -Dversion=%4 -Dpackage=%package%

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Jbatch.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Jbatch.rst
@@ -53,16 +53,41 @@ Nablarchが提供するアーキタイプを使用してブランクプロジェ
 mvnコマンドの実行
 -------------------------------------------------------
 
-カレントディレクトリを、ブランクプロジェクトを作成したいディレクトリ(任意のディレクトリで可)に変更し、以下のファイルを配置する。
+`Maven Archetype Plugin(外部サイト、英語) <https://maven.apache.org/archetype/maven-archetype-plugin/usage.html>`_ を使用して、ブランクプロジェクトを生成する。
 
-:download:`バッチファイル <bat/generateJbatchProject.bat>`
+カレントディレクトリを、ブランクプロジェクトを作成したいディレクトリ(任意のディレクトリで可)に変更する。
 
-配置後、引数に必要なパラメータを指定しbatファイルを実行する。
+その後、以下のコマンドを実行する。
 
-generateJbatchProject.bat |nablarch_version| <<groupId>> <<artifactId>> <<version>> <<package(任意)>>
+.. code-block:: bat
 
-上記コマンドに設定するパラメータは以下の通り。
-なお、nablarchのバージョンを変更したい場合には |nablarch_version| を変更すること。
+  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-ee-archetype -DarchetypeVersion={nablarch_version}
+
+上記コマンドで使用されているNablarchのバージョンは |nablarch_version| となっている。バージョンを変更したい場合は、以下のパラメータを変更すること。
+
+.. list-table::
+  :header-rows: 1
+  :class: white-space-normal
+  :widths: 6,20
+
+  * - 設定値
+    - 説明
+  * - archetypeVersion
+    - 使用したいアーキタイプのバージョンを指定する。（Nablarch 5u25以降を指定すること）
+
+.. tip::
+  Nablarch 5u24以前のバージョンでブランクプロジェクトを生成したい場合は、上記コマンドの ``archetype:generate`` を ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` に変更して以下の例のように実行すること。
+
+  .. code-block:: bat
+
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-ee-archetype -DarchetypeVersion=5u24
+
+  この例で使用されているNablarchのバージョンは 5u24 となっている。バージョン変更したい場合は、同様にパラメータarchetypeVersionを変更すること。
+
+プロジェクト情報の入力
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+上記コマンドを実行すると、以下の項目について入力を求められるので、 生成されるブランクプロジェクトに関する情報を入力する。
 
 =========== ========================================= =======================
 入力項目    説明                                      設定例
@@ -76,6 +101,11 @@ package      パッケージ(通常はグループIDと同じ)       ``com.examp
 .. important::
    項目groupIdおよびpackageは、Javaのパッケージ名にマッピングされる。
    よって、これらの入力値には、英小文字、数字、ドットを使用し、ハイフンは使用しないこと。
+
+プロジェクト情報の入力が終わると、Y: :と表示される。
+
+ * 入力した内容をもとに、ひな形を生成する場合には「Y」を入力してください。
+ * プロジェクト情報の入力をやり直したい場合には「N」を入力してください。
 
 コマンドが正常終了した場合、ブランクプロジェクトがカレントディレクトリ配下に作成される。
 

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_NablarchBatch.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_NablarchBatch.rst
@@ -56,17 +56,41 @@ Nablarchが提供するアーキタイプを使用してブランクプロジェ
 mvnコマンドの実行
 ~~~~~~~~~~~~~~~~~
 
-カレントディレクトリを、ブランクプロジェクトを作成したいディレクトリ(任意のディレクトリで可)に変更し、以下のファイルを配置する。
+`Maven Archetype Plugin(外部サイト、英語) <https://maven.apache.org/archetype/maven-archetype-plugin/usage.html>`_ を使用して、ブランクプロジェクトを生成する。
 
-:download:`バッチファイル <bat/generateNablarchBatchProject.bat>`
-
-配置後、引数に必要なパラメータを指定しbatファイルを実行する。
-
-generateNablarchBatchProject.bat |nablarch_version| <<groupId>> <<artifactId>> <<version>> <<package(任意)>>
-
-上記コマンドに設定するパラメータは以下の通り。
-なお、nablarchのバージョンを変更したい場合には |nablarch_version| を変更すること。
 カレントディレクトリを、ブランクプロジェクトを作成したいディレクトリ(任意のディレクトリで可)に変更する。
+
+その後、以下のコマンドを実行する。
+
+.. code-block:: bat
+
+  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-archetype -DarchetypeVersion={nablarch_version}
+
+上記コマンドで使用されているNablarchのバージョンは |nablarch_version| となっている。バージョンを変更したい場合は、以下のパラメータを変更すること。
+
+.. list-table::
+  :header-rows: 1
+  :class: white-space-normal
+  :widths: 6,20
+
+  * - 設定値
+    - 説明
+  * - archetypeVersion
+    - 使用したいアーキタイプのバージョンを指定する。（Nablarch 5u25以降を指定すること）
+
+.. tip::
+  Nablarch 5u24以前のバージョンでブランクプロジェクトを生成したい場合は、上記コマンドの ``archetype:generate`` を ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` に変更して以下の例のように実行すること。
+
+  .. code-block:: bat
+
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-archetype -DarchetypeVersion=5u24
+
+  この例で使用されているNablarchのバージョンは 5u24 となっている。バージョン変更したい場合は、同様にパラメータarchetypeVersionを変更すること。
+
+プロジェクト情報の入力
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+上記コマンドを実行すると、以下の項目について入力を求められるので、 生成されるブランクプロジェクトに関する情報を入力する。
 
 =========== ========================================= =======================
 入力項目    説明                                      設定例
@@ -80,6 +104,11 @@ package      パッケージ(通常はグループIDと同じ)       ``com.examp
 .. important::
    項目groupIdおよびpackageは、Javaのパッケージ名にマッピングされる。
    よって、これらの入力値には、英小文字、数字、ドットを使用し、ハイフンは使用しないこと。
+
+プロジェクト情報の入力が終わると、Y: :と表示される。
+
+ * 入力した内容をもとに、ひな形を生成する場合には「Y」を入力してください。
+ * プロジェクト情報の入力をやり直したい場合には「N」を入力してください。
 
 コマンドが正常終了した場合、ブランクプロジェクトがカレントディレクトリ配下に作成される。
 

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_NablarchBatch_Dbless.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_NablarchBatch_Dbless.rst
@@ -46,17 +46,41 @@ Nablarchが提供するアーキタイプを使用してブランクプロジェ
 mvnコマンドの実行
 ~~~~~~~~~~~~~~~~~
 
-カレントディレクトリを、ブランクプロジェクトを作成したいディレクトリ(任意のディレクトリで可)に変更し、以下のファイルを配置する。
+`Maven Archetype Plugin(外部サイト、英語) <https://maven.apache.org/archetype/maven-archetype-plugin/usage.html>`_ を使用して、ブランクプロジェクトを生成する。
 
-:download:`バッチファイル <bat/generateNablarchBatchDblessProject.bat>`
-
-配置後、引数に必要なパラメータを指定しbatファイルを実行する。
-
-generateNablarchBatchDblessProject.bat |nablarch_version| <<groupId>> <<artifactId>> <<version>> <<package(任意)>>
-
-上記コマンドに設定するパラメータは以下の通り。
-なお、nablarchのバージョンを変更したい場合には |nablarch_version| を変更すること。
 カレントディレクトリを、ブランクプロジェクトを作成したいディレクトリ(任意のディレクトリで可)に変更する。
+
+その後、以下のコマンドを実行する。
+
+.. code-block:: bat
+
+  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-dbless-archetype -DarchetypeVersion={nablarch_version}
+
+上記コマンドで使用されているNablarchのバージョンは |nablarch_version| となっている。バージョンを変更したい場合は、以下のパラメータを変更すること。
+
+.. list-table::
+  :header-rows: 1
+  :class: white-space-normal
+  :widths: 6,20
+
+  * - 設定値
+    - 説明
+  * - archetypeVersion
+    - 使用したいアーキタイプのバージョンを指定する。（Nablarch 5u25以降を指定すること）
+
+.. tip::
+  Nablarch 5u24以前のバージョンでブランクプロジェクトを生成したい場合は、上記コマンドの ``archetype:generate`` を ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` に変更して以下の例のように実行すること。
+
+  .. code-block:: bat
+
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-dbless-archetype -DarchetypeVersion=5u24
+
+  この例で使用されているNablarchのバージョンは 5u24 となっている。バージョン変更したい場合は、同様にパラメータarchetypeVersionを変更すること。
+
+プロジェクト情報の入力
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+上記コマンドを実行すると、以下の項目について入力を求められるので、 生成されるブランクプロジェクトに関する情報を入力する。
 
 =========== ========================================= =======================
 入力項目    説明                                      設定例
@@ -70,6 +94,11 @@ package      パッケージ(通常はグループIDと同じ)       ``com.examp
 .. important::
    項目groupIdおよびpackageは、Javaのパッケージ名にマッピングされる。
    よって、これらの入力値には、英小文字、数字、ドットを使用し、ハイフンは使用しないこと。
+
+プロジェクト情報の入力が終わると、Y: :と表示される。
+
+ * 入力した内容をもとに、ひな形を生成する場合には「Y」を入力してください。
+ * プロジェクト情報の入力をやり直したい場合には「N」を入力してください。
 
 コマンドが正常終了した場合、ブランクプロジェクトがカレントディレクトリ配下に作成される。
 

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
@@ -57,7 +57,7 @@ mvnコマンドの実行
 
 .. code-block:: text
 
-  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=
+  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion={nablarch_version}
 
 上記コマンドで使用されているnablarchのバージョンは |nablarch_version| となっている。バージョンを変更したい場合は、以下のパラメータを変更すること。
 

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
@@ -72,7 +72,9 @@ mvnコマンドの実行
     - 使用したいアーキタイプのバージョンを指定する。（Nablarch 5u25以降を指定すること）
 
 .. tip::
-  Nablarch 5u24以前のバージョンを使用したい場合は、上記コマンドは使用できない。以下のコマンドの <<version>> を使用したいバージョンに変更し、実行すること。
+  Nablarch 5u24以前のバージョンでブランクプロジェクトを生成したい場合は、上記コマンドの ``archetype:generate`` を ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` に変更して以下のコマンド例のように実行すること。
+
+  バージョン指定も同様にパラメータarchetypeVersionで行う。
 
   .. code-block:: bat
 

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
@@ -51,16 +51,38 @@ mvnコマンドの実行
 
 `Maven Archetype Plugin(外部サイト、英語) <https://maven.apache.org/archetype/maven-archetype-plugin/usage.html>`_ を使用して、ブランクプロジェクトを生成する。
 
-カレントディレクトリを、ブランクプロジェクトを作成したいディレクトリ(任意のディレクトリで可)に変更し、以下のファイルを配置する。
+カレントディレクトリを、ブランクプロジェクトを作成したいディレクトリ(任意のディレクトリで可)に変更する。
 
-:download:`バッチファイル <bat/generateWebProject.bat>`
+その後、以下のコマンドを実行する。
 
-配置後、引数に必要なパラメータを指定しbatファイルを実行する。
+.. code-block:: text
 
-generateWebProject.bat |nablarch_version| <<groupId>> <<artifactId>> <<version>> <<package(任意)>>
+  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=
 
-上記コマンドに設定するパラメータは以下の通り。
-なお、nablarchのバージョンを変更したい場合には |nablarch_version| を変更すること。
+上記コマンドで使用されているnablarchのバージョンは |nablarch_version| となっている。バージョンを変更したい場合は、以下のパラメータを変更すること。
+
+.. list-table::
+  :header-rows: 1
+  :class: white-space-normal
+  :widths: 6,20
+
+  * - 設定値
+    - 説明
+  * - archetypeVersion
+    - 使用したいアーキタイプのバージョンを指定する（Nablarch 5u25以降のバージョン）
+
+.. tip::
+  Nablarch 5u24以前のバージョンを使用したい場合は、上記コマンドは使用できない。以下のコマンドを実行すること。
+
+  .. code-block:: text
+
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
+
+
+プロジェクト情報の入力
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+上記コマンドを実行すると、以下の項目について入力を求められるので、 生成されるブランクプロジェクトに関する情報を入力する。
 
 =========== ========================================= =======================
 入力項目    説明                                      設定例
@@ -74,6 +96,11 @@ package      パッケージ(通常はグループIDと同じ)       ``com.examp
 .. important::
    項目groupIdおよびpackageは、Javaのパッケージ名にマッピングされる。
    よって、これらの入力値には、英小文字、数字、ドットを使用し、ハイフンは使用しないこと。
+
+プロジェクト情報の入力が終わると、Y: :と表示される。
+
+ * 入力した内容をもとに、ひな形を生成する場合には「Y」を入力してください。
+ * プロジェクト情報の入力をやり直したい場合には「N」を入力してください。
 
 コマンドが正常終了した場合、ブランクプロジェクトがカレントディレクトリ配下に作成される。
 

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
@@ -74,12 +74,11 @@ mvnコマンドの実行
 .. tip::
   Nablarch 5u24以前のバージョンでブランクプロジェクトを生成したい場合は、上記コマンドの ``archetype:generate`` を ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` に変更して以下のコマンド例のように実行すること。
 
-  バージョン指定も同様にパラメータarchetypeVersionで行う。
-
   .. code-block:: bat
 
-    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype ^
-        -DarchetypeVersion=<<version>>
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
+
+  コマンド例で使用されているnablarchのバージョンは 5u24 となっている。バージョン変更したい場合は、同様にパラメータarchetypeVersionを変更すること。
 
 プロジェクト情報の入力
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
@@ -55,7 +55,7 @@ mvnコマンドの実行
 
 その後、以下のコマンドを実行する。
 
-.. code-block:: text
+.. code-block:: bat
 
   mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion={nablarch_version}
 
@@ -69,15 +69,15 @@ mvnコマンドの実行
   * - 設定値
     - 説明
   * - archetypeVersion
-    - 使用したいアーキタイプのバージョンを指定する（Nablarch 5u25以降のバージョン）
+    - 使用したいアーキタイプのバージョンを指定する。（Nablarch 5u25以降を指定すること）
 
 .. tip::
-  Nablarch 5u24以前のバージョンを使用したい場合は、上記コマンドは使用できない。以下のコマンドを実行すること。
+  Nablarch 5u24以前のバージョンを使用したい場合は、上記コマンドは使用できない。以下のコマンドの <<version>> を使用したいバージョンに変更し、実行すること。
 
-  .. code-block:: text
+  .. code-block:: bat
 
-    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
-
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype ^
+        -DarchetypeVersion=<<version>>
 
 プロジェクト情報の入力
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Web.rst
@@ -59,7 +59,7 @@ mvnコマンドの実行
 
   mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion={nablarch_version}
 
-上記コマンドで使用されているnablarchのバージョンは |nablarch_version| となっている。バージョンを変更したい場合は、以下のパラメータを変更すること。
+上記コマンドで使用されているNablarchのバージョンは |nablarch_version| となっている。バージョンを変更したい場合は、以下のパラメータを変更すること。
 
 .. list-table::
   :header-rows: 1
@@ -72,13 +72,13 @@ mvnコマンドの実行
     - 使用したいアーキタイプのバージョンを指定する。（Nablarch 5u25以降を指定すること）
 
 .. tip::
-  Nablarch 5u24以前のバージョンでブランクプロジェクトを生成したい場合は、上記コマンドの ``archetype:generate`` を ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` に変更して以下のコマンド例のように実行すること。
+  Nablarch 5u24以前のバージョンでブランクプロジェクトを生成したい場合は、上記コマンドの ``archetype:generate`` を ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` に変更して以下の例のように実行すること。
 
   .. code-block:: bat
 
     mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=5u24
 
-  コマンド例で使用されているnablarchのバージョンは 5u24 となっている。バージョン変更したい場合は、同様にパラメータarchetypeVersionを変更すること。
+  この例で使用されているNablarchのバージョンは 5u24 となっている。バージョン変更したい場合は、同様にパラメータarchetypeVersionを変更すること。
 
 プロジェクト情報の入力
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_WebService.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_WebService.rst
@@ -63,16 +63,39 @@ mvnコマンドの実行
 
 `Maven Archetype Plugin(外部サイト、英語) <https://maven.apache.org/archetype/maven-archetype-plugin/usage.html>`_ を使用して、ブランクプロジェクトを生成する。
 
-カレントディレクトリを、ブランクプロジェクトを作成したいディレクトリ(任意のディレクトリで可)に変更し、以下のファイルを配置する。
+カレントディレクトリを、ブランクプロジェクトを作成したいディレクトリ(任意のディレクトリで可)に変更する。
 
-:download:`バッチファイル <bat/generateWebServiceProject.bat>`
+その後、以下のコマンドを実行する。
 
-配置後、引数に必要なパラメータを指定しbatファイルを実行する。
+.. code-block:: bat
 
-generateWebServiceProject.bat |nablarch_version| <<groupId>> <<artifactId>> <<version>> <<package(任意)>>
+  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-jaxrs-archetype -DarchetypeVersion={nablarch_version}
 
-上記コマンドに設定するパラメータは以下の通り。
-なお、nablarchのバージョンを変更したい場合には |nablarch_version| を変更すること。
+上記コマンドで使用されているNablarchのバージョンは |nablarch_version| となっている。バージョンを変更したい場合は、以下のパラメータを変更すること。
+
+.. list-table::
+  :header-rows: 1
+  :class: white-space-normal
+  :widths: 6,20
+
+  * - 設定値
+    - 説明
+  * - archetypeVersion
+    - 使用したいアーキタイプのバージョンを指定する。（Nablarch 5u25以降を指定すること）
+
+.. tip::
+  Nablarch 5u24以前のバージョンでブランクプロジェクトを生成したい場合は、上記コマンドの ``archetype:generate`` を ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` に変更して以下の例のように実行すること。
+
+  .. code-block:: bat
+
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-jaxrs-archetype -DarchetypeVersion=5u24
+
+  この例で使用されているNablarchのバージョンは 5u24 となっている。バージョン変更したい場合は、同様にパラメータarchetypeVersionを変更すること。
+
+プロジェクト情報の入力
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+上記コマンドを実行すると、以下の項目について入力を求められるので、 生成されるブランクプロジェクトに関する情報を入力する。
 
 =========== ========================================= =======================
 入力項目    説明                                      設定例
@@ -87,6 +110,10 @@ package      パッケージ(通常はグループIDと同じ)       ``com.examp
    項目groupIdおよびpackageは、Javaのパッケージ名にマッピングされる。
    よって、これらの入力値には、英小文字、数字、ドットを使用し、ハイフンは使用しないこと。
 
+プロジェクト情報の入力が終わると、Y: :と表示される。
+
+ * 入力した内容をもとに、ひな形を生成する場合には「Y」を入力してください。
+ * プロジェクト情報の入力をやり直したい場合には「N」を入力してください。
 
 コマンドが正常終了した場合、ブランクプロジェクトがカレントディレクトリ配下に作成される。
 

--- a/ja/application_framework/application_framework/blank_project/setup_containerBlankProject/bat/generateContainerNablarchBatchDblessProject.bat
+++ b/ja/application_framework/application_framework/blank_project/setup_containerBlankProject/bat/generateContainerNablarchBatchDblessProject.bat
@@ -1,7 +1,0 @@
-if "%5" EQU "" (
-  set package=%2
-) else (
-  set package=%5
-)
-
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DinteractiveMode=false -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-dbless-archetype -DarchetypeVersion=%1 -DgroupId=%2 -DartifactId=%3 -Dversion=%4 -Dpackage=%package%

--- a/ja/application_framework/application_framework/blank_project/setup_containerBlankProject/bat/generateContainerNablarchBatchProject.bat
+++ b/ja/application_framework/application_framework/blank_project/setup_containerBlankProject/bat/generateContainerNablarchBatchProject.bat
@@ -1,7 +1,0 @@
-if "%5" EQU "" (
-  set package=%2
-) else (
-  set package=%5
-)
-
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DinteractiveMode=false -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-archetype -DarchetypeVersion=%1 -DgroupId=%2 -DartifactId=%3 -Dversion=%4 -Dpackage=%package%

--- a/ja/application_framework/application_framework/blank_project/setup_containerBlankProject/bat/generateContainerWebProject.bat
+++ b/ja/application_framework/application_framework/blank_project/setup_containerBlankProject/bat/generateContainerWebProject.bat
@@ -1,7 +1,0 @@
-if "%5" EQU "" (
-  set package=%2
-) else (
-  set package=%5
-)
-
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DinteractiveMode=false -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-web-archetype -DarchetypeVersion=%1 -DgroupId=%2 -DartifactId=%3 -Dversion=%4 -Dpackage=%package%

--- a/ja/application_framework/application_framework/blank_project/setup_containerBlankProject/bat/generateContainerWebServiceProject.bat
+++ b/ja/application_framework/application_framework/blank_project/setup_containerBlankProject/bat/generateContainerWebServiceProject.bat
@@ -1,7 +1,0 @@
-if "%5" EQU "" (
-  set package=%2
-) else (
-  set package=%5
-)
-
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DinteractiveMode=false -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-jaxrs-archetype -DarchetypeVersion=%1 -DgroupId=%2 -DartifactId=%3 -Dversion=%4 -Dpackage=%package%

--- a/ja/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerBatch.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerBatch.rst
@@ -59,17 +59,39 @@ mvnコマンドの実行
 
 `Maven Archetype Plugin(外部サイト、英語) <https://maven.apache.org/archetype/maven-archetype-plugin/usage.html>`_ を使用して、ブランクプロジェクトを生成する。
 
-カレントディレクトリを、ブランクプロジェクトを作成したいディレクトリ(任意のディレクトリで可)に変更し、以下のファイルを配置する。
-
-:download:`バッチファイル <bat/generateContainerNablarchBatchProject.bat>`
-
-配置後、引数に必要なパラメータを指定しbatファイルを実行する。
-
-generateContainerNablarchBatchProject.bat |nablarch_version| <<groupId>> <<artifactId>> <<version>> <<package(任意)>>
-
-上記コマンドに設定するパラメータは以下の通り。
-なお、nablarchのバージョンを変更したい場合には |nablarch_version| を変更すること。
 カレントディレクトリを、ブランクプロジェクトを作成したいディレクトリ(任意のディレクトリで可)に変更する。
+
+その後、以下のコマンドを実行する。
+
+.. code-block:: bat
+
+  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-archetype -DarchetypeVersion={nablarch_version}
+
+上記コマンドで使用されているNablarchのバージョンは |nablarch_version| となっている。バージョンを変更したい場合は、以下のパラメータを変更すること。
+
+.. list-table::
+  :header-rows: 1
+  :class: white-space-normal
+  :widths: 6,20
+
+  * - 設定値
+    - 説明
+  * - archetypeVersion
+    - 使用したいアーキタイプのバージョンを指定する。（Nablarch 5u25以降を指定すること）
+
+.. tip::
+  Nablarch 5u24以前のバージョンでブランクプロジェクトを生成したい場合は、上記コマンドの ``archetype:generate`` を ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` に変更して以下の例のように実行すること。
+
+  .. code-block:: bat
+
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-archetype -DarchetypeVersion=5u24
+
+  この例で使用されているNablarchのバージョンは 5u24 となっている。バージョン変更したい場合は、同様にパラメータarchetypeVersionを変更すること。
+
+プロジェクト情報の入力
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+上記コマンドを実行すると、以下の項目について入力を求められるので、 生成されるブランクプロジェクトに関する情報を入力する。
 
 =========== ========================================= =======================
 入力項目    説明                                      設定例
@@ -83,6 +105,11 @@ package      パッケージ(通常はグループIDと同じ)       ``com.examp
 .. important::
    項目groupIdおよびpackageは、Javaのパッケージ名にマッピングされる。
    よって、これらの入力値には、英小文字、数字、ドットを使用し、ハイフンは使用しないこと。
+
+プロジェクト情報の入力が終わると、Y: :と表示される。
+
+ * 入力した内容をもとに、ひな形を生成する場合には「Y」を入力してください。
+ * プロジェクト情報の入力をやり直したい場合には「N」を入力してください。
 
 コマンドが正常終了した場合、ブランクプロジェクトがカレントディレクトリ配下に作成される。
 

--- a/ja/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerBatch_Dbless.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerBatch_Dbless.rst
@@ -49,17 +49,39 @@ mvnコマンドの実行
 
 `Maven Archetype Plugin(外部サイト、英語) <https://maven.apache.org/archetype/maven-archetype-plugin/usage.html>`_ を使用して、ブランクプロジェクトを生成する。
 
-カレントディレクトリを、ブランクプロジェクトを作成したいディレクトリ(任意のディレクトリで可)に変更し、以下のファイルを配置する。
-
-:download:`バッチファイル <bat/generateContainerNablarchBatchDblessProject.bat>`
-
-配置後、引数に必要なパラメータを指定しbatファイルを実行する。
-
-generateContainerNablarchBatchDblessProject.bat |nablarch_version| <<groupId>> <<artifactId>> <<version>> <<package(任意)>>
-
-上記コマンドに設定するパラメータは以下の通り。
-なお、nablarchのバージョンを変更したい場合には |nablarch_version| を変更すること。
 カレントディレクトリを、ブランクプロジェクトを作成したいディレクトリ(任意のディレクトリで可)に変更する。
+
+その後、以下のコマンドを実行する。
+
+.. code-block:: bat
+
+  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-dbless-archetype -DarchetypeVersion={nablarch_version}
+
+上記コマンドで使用されているNablarchのバージョンは |nablarch_version| となっている。バージョンを変更したい場合は、以下のパラメータを変更すること。
+
+.. list-table::
+  :header-rows: 1
+  :class: white-space-normal
+  :widths: 6,20
+
+  * - 設定値
+    - 説明
+  * - archetypeVersion
+    - 使用したいアーキタイプのバージョンを指定する。（Nablarch 5u25以降を指定すること）
+
+.. tip::
+  Nablarch 5u24以前のバージョンでブランクプロジェクトを生成したい場合は、上記コマンドの ``archetype:generate`` を ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` に変更して以下の例のように実行すること。
+
+  .. code-block:: bat
+
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-dbless-archetype -DarchetypeVersion=5u24
+
+  この例で使用されているNablarchのバージョンは 5u24 となっている。バージョン変更したい場合は、同様にパラメータarchetypeVersionを変更すること。
+
+プロジェクト情報の入力
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+上記コマンドを実行すると、以下の項目について入力を求められるので、 生成されるブランクプロジェクトに関する情報を入力する。
 
 =========== ========================================= =======================
 入力項目    説明                                      設定例
@@ -73,6 +95,11 @@ package      パッケージ(通常はグループIDと同じ)       ``com.examp
 .. important::
    項目groupIdおよびpackageは、Javaのパッケージ名にマッピングされる。
    よって、これらの入力値には、英小文字、数字、ドットを使用し、ハイフンは使用しないこと。
+
+プロジェクト情報の入力が終わると、Y: :と表示される。
+
+ * 入力した内容をもとに、ひな形を生成する場合には「Y」を入力してください。
+ * プロジェクト情報の入力をやり直したい場合には「N」を入力してください。
 
 コマンドが正常終了した場合、ブランクプロジェクトがカレントディレクトリ配下に作成される。
 

--- a/ja/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerWeb.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerWeb.rst
@@ -53,16 +53,39 @@ mvnコマンドの実行
 
 `Maven Archetype Plugin(外部サイト、英語) <https://maven.apache.org/archetype/maven-archetype-plugin/usage.html>`_ を使用して、ブランクプロジェクトを生成する。
 
-カレントディレクトリを、ブランクプロジェクトを作成したいディレクトリ(任意のディレクトリで可)に変更し、以下のファイルを配置する。
+カレントディレクトリを、ブランクプロジェクトを作成したいディレクトリ(任意のディレクトリで可)に変更する。
 
-:download:`バッチファイル <bat/generateContainerWebProject.bat>`
+その後、以下のコマンドを実行する。
 
-配置後、引数に必要なパラメータを指定しbatファイルを実行する。
+.. code-block:: bat
 
-generateContainerWebProject.bat |nablarch_version| <<groupId>> <<artifactId>> <<version>> <<package(任意)>>
+  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-web-archetype -DarchetypeVersion={nablarch_version}
 
-上記コマンドに設定するパラメータは以下の通り。
-なお、nablarchのバージョンを変更したい場合には |nablarch_version| を変更すること。
+上記コマンドで使用されているNablarchのバージョンは |nablarch_version| となっている。バージョンを変更したい場合は、以下のパラメータを変更すること。
+
+.. list-table::
+  :header-rows: 1
+  :class: white-space-normal
+  :widths: 6,20
+
+  * - 設定値
+    - 説明
+  * - archetypeVersion
+    - 使用したいアーキタイプのバージョンを指定する。（Nablarch 5u25以降を指定すること）
+
+.. tip::
+  Nablarch 5u24以前のバージョンでブランクプロジェクトを生成したい場合は、上記コマンドの ``archetype:generate`` を ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` に変更して以下の例のように実行すること。
+
+  .. code-block:: bat
+
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-web-archetype -DarchetypeVersion=5u24
+
+  この例で使用されているNablarchのバージョンは 5u24 となっている。バージョン変更したい場合は、同様にパラメータarchetypeVersionを変更すること。
+
+プロジェクト情報の入力
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+上記コマンドを実行すると、以下の項目について入力を求められるので、 生成されるブランクプロジェクトに関する情報を入力する。
 
 =========== ========================================= =======================
 入力項目    説明                                      設定例
@@ -76,6 +99,11 @@ package      パッケージ(通常はグループIDと同じ)       ``com.examp
 .. important::
    項目groupIdおよびpackageは、Javaのパッケージ名にマッピングされる。
    よって、これらの入力値には、英小文字、数字、ドットを使用し、ハイフンは使用しないこと。
+
+プロジェクト情報の入力が終わると、Y: :と表示される。
+
+ * 入力した内容をもとに、ひな形を生成する場合には「Y」を入力してください。
+ * プロジェクト情報の入力をやり直したい場合には「N」を入力してください。
 
 コマンドが正常終了した場合、ブランクプロジェクトがカレントディレクトリ配下に作成される。
 

--- a/ja/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerWebService.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_containerBlankProject/setup_ContainerWebService.rst
@@ -65,16 +65,39 @@ mvnコマンドの実行
 
 `Maven Archetype Plugin(外部サイト、英語) <https://maven.apache.org/archetype/maven-archetype-plugin/usage.html>`_ を使用して、ブランクプロジェクトを生成する。
 
-カレントディレクトリを、ブランクプロジェクトを作成したいディレクトリ(任意のディレクトリで可)に変更し、以下のファイルを配置する。
+カレントディレクトリを、ブランクプロジェクトを作成したいディレクトリ(任意のディレクトリで可)に変更する。
 
-:download:`バッチファイル <bat/generateContainerWebServiceProject.bat>`
+その後、以下のコマンドを実行する。
 
-配置後、引数に必要なパラメータを指定しbatファイルを実行する。
+.. code-block:: bat
 
-generateContainerWebServiceProject.bat |nablarch_version| <<groupId>> <<artifactId>> <<version>> <<package(任意)>>
+  mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-jaxrs-archetype -DarchetypeVersion={nablarch_version}
 
-上記コマンドに設定するパラメータは以下の通り。
-なお、nablarchのバージョンを変更したい場合には |nablarch_version| を変更すること。
+上記コマンドで使用されているNablarchのバージョンは |nablarch_version| となっている。バージョンを変更したい場合は、以下のパラメータを変更すること。
+
+.. list-table::
+  :header-rows: 1
+  :class: white-space-normal
+  :widths: 6,20
+
+  * - 設定値
+    - 説明
+  * - archetypeVersion
+    - 使用したいアーキタイプのバージョンを指定する。（Nablarch 5u25以降を指定すること）
+
+.. tip::
+  Nablarch 5u24以前のバージョンでブランクプロジェクトを生成したい場合は、上記コマンドの ``archetype:generate`` を ``org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`` に変更して以下の例のように実行すること。
+
+  .. code-block:: bat
+
+    mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-jaxrs-archetype -DarchetypeVersion=5u24
+
+  この例で使用されているNablarchのバージョンは 5u24 となっている。バージョン変更したい場合は、同様にパラメータarchetypeVersionを変更すること。
+
+プロジェクト情報の入力
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+上記コマンドを実行すると、以下の項目について入力を求められるので、 生成されるブランクプロジェクトに関する情報を入力する。
 
 =========== ========================================= =======================
 入力項目    説明                                      設定例
@@ -89,6 +112,10 @@ package      パッケージ(通常はグループIDと同じ)       ``com.examp
    項目groupIdおよびpackageは、Javaのパッケージ名にマッピングされる。
    よって、これらの入力値には、英小文字、数字、ドットを使用し、ハイフンは使用しないこと。
 
+プロジェクト情報の入力が終わると、Y: :と表示される。
+
+ * 入力した内容をもとに、ひな形を生成する場合には「Y」を入力してください。
+ * プロジェクト情報の入力をやり直したい場合には「N」を入力してください。
 
 コマンドが正常終了した場合、ブランクプロジェクトがカレントディレクトリ配下に作成される。
 

--- a/ja/conf.py
+++ b/ja/conf.py
@@ -316,11 +316,30 @@ javadoc_url_map = {
   'javax.ws' : ('https://docs.oracle.com/javaee/7/api/', 'javadoc8')
 }
 
-# add custom javascript
-def setup(app):
-  app.add_javascript('custom.js')
-  
 rst_prolog= u".. |nablarch_version| replace:: " + version + """
 """
 
 extlinks = {'javadoc_url' : ('https://nablarch.github.io/docs/' + version + '/publishedApi/%s', 'path')}
+
+# Configure the Sphinx extension
+def setup(app):
+   # add custom javascript
+   app.add_javascript('custom.js')
+
+   # add custom config for Nablarch version replacements
+   app.add_config_value('replacements_dict', {}, True)
+   # add an event handler to replace the Nablarch version
+   app.connect('source-read', replaceNablarchVersion)
+
+# Options for Nablarch version replacements
+# Code blocks cannot be replaced in the |nablarch_version| format, so they are explicitly replaced before documentation is generated.
+
+def replaceNablarchVersion(app, docname, source):
+    result = source[0]
+    for key in app.config.replacements_dict:
+        result = result.replace(key, app.config.replacements_dict[key])
+    source[0] = result
+
+replacements_dict = {
+    "{nablarch_version}" : version
+}

--- a/ja/conf.py
+++ b/ja/conf.py
@@ -321,25 +321,27 @@ rst_prolog= u".. |nablarch_version| replace:: " + version + """
 
 extlinks = {'javadoc_url' : ('https://nablarch.github.io/docs/' + version + '/publishedApi/%s', 'path')}
 
-# Configure the Sphinx extension
+# Sphinx の拡張機能を設定するための関数
 def setup(app):
-   # add custom javascript
+   # カスタムのjavascriptファイルを追加する。
    app.add_javascript('custom.js')
 
-   # add custom config for Nablarch version replacements
-   app.add_config_value('replacements_dict', {}, True)
-   # add an event handler to replace the Nablarch version
-   app.connect('source-read', replaceNablarchVersion)
+   # Sphinxの設定に辞書replacements_for_source_readを追加する。
+   app.add_config_value('replacements_for_source_read', {}, True)
+   # Sphinxがドキュメントのソースコードを読み込んだ際にイベントハンドラを呼び出すように設定する。
+   app.connect('source-read', replace_in_document_sources)
 
-# Options for Nablarch version replacements
-# Code blocks cannot be replaced in the |nablarch_version| format, so they are explicitly replaced before documentation is generated.
-
-def replaceNablarchVersion(app, docname, source):
+# code-blockではrst_prologで定義した変数展開が行えないため、ドキュメントのソースコードをSphinxが読み取る際に文字列置換することでcode-block内で疑似的に変数展開を行うために導入する関数
+# source-readイベントで呼び出されるように登録し、辞書replacements_for_source_readに登録されているキーと値に文字列置換を行う。
+# ドキュメント内の文字列を辞書replacements_for_source_readで登録した内容で単純に文字列置換するため、辞書のキーに登録した文字列をそのまま表示できなくなることに注意すること。
+def replace_in_document_sources(app, docname, source):
     result = source[0]
-    for key in app.config.replacements_dict:
-        result = result.replace(key, app.config.replacements_dict[key])
+    for key in app.config.replacements_for_source_read:
+        result = result.replace(key, app.config.replacements_for_source_read[key])
     source[0] = result
 
-replacements_dict = {
+# 登録されたキーと値がソースコードを読み込む際に文字列置換される辞書
+# 辞書のキーに登録した文字列をそのまま表示できなくなるリスクがあるので、現状使用箇所がなく、|nablarch_version|に表記が近い{nabalrch_version}を定義している。
+replacements_for_source_read = {
     "{nablarch_version}" : version
 }


### PR DESCRIPTION
https://github.com/nablarch/nablarch-document/pull/637 の5系対応をしました。

6系と異なる点は以下です。

- 5u24以前でブランクプロジェクトを作成するには、以前batファイルで案内していた`mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate`を使う必要があるため補足として追記しました。