### PR TITLE
MicerometerのDatadog連携で使用するサイトURLの記載を修正（v6）

### DIFF
--- a/en/application_framework/adaptors/micrometer_adaptor.rst
+++ b/en/application_framework/adaptors/micrometer_adaptor.rst
@@ -535,12 +535,12 @@ Configuring the API key
 
   The API key can be set in ``nablarch.micrometer.datadog.apiKey`` .
 
-Configuring the URI
+Configuring the site URL
   .. code-block:: text
 
     nablarch.micrometer.datadog.uri=<SITE_URL>
 
-  The URI can be set in ``nablarch.micrometer.datadog.uri`` .
+  The site URL can be set in ``nablarch.micrometer.datadog.uri`` .
 
   See `DatadogConfig (external site)`_ for other configuration.
 

--- a/ja/application_framework/adaptors/micrometer_adaptor.rst
+++ b/ja/application_framework/adaptors/micrometer_adaptor.rst
@@ -530,14 +530,14 @@ APIキーを設定する
 
     nablarch.micrometer.datadog.apiKey=XXXXXXXXXXXXXXXX
 
-  API キーは ``nablarch.micrometer.datadog.apiKey`` で設定できる。
+  APIキーは ``nablarch.micrometer.datadog.apiKey`` で設定できる。
 
-URIを設定する
+サイトURLを設定する
   .. code-block:: text
 
-    nablarch.micrometer.datadog.uri=<サイトのURL>
+    nablarch.micrometer.datadog.uri=<サイトURL>
 
-  URI は ``nablarch.micrometer.datadog.uri`` で設定できる。
+  サイトURLは ``nablarch.micrometer.datadog.uri`` で設定できる。
 
   その他の設定については `DatadogConfig(外部サイト、英語)`_ を参照。
 


### PR DESCRIPTION
MicrometerのDatadog連携で使用するサイトURLの記載を、[Datadogのガイドにある表現](https://docs.datadoghq.com/ja/getting_started/site/)に近しくなるように修正しました。