### PR TITLE
masterブランチへの参照をmainブランチに変更

### DIFF
--- a/en/about_nablarch/mvn_module.rst
+++ b/en/about_nablarch/mvn_module.rst
@@ -5,4 +5,4 @@ Module List of Nablarch
 ==================================================
 
 Object code and source code of Java of Nablarch are published in `Maven Central <https://repo1.maven.org/maven2/com/nablarch/>`_   
-. For the modules provided, see the `Module list <https://github.com/nablarch/nablarch/blob/master/README.md/>`_ 
+. For the modules provided, see the `Module list <https://github.com/nablarch/nablarch/blob/main/README.md/>`_

--- a/en/about_nablarch/mvn_module.rst
+++ b/en/about_nablarch/mvn_module.rst
@@ -5,4 +5,4 @@ Module List of Nablarch
 ==================================================
 
 Object code and source code of Java of Nablarch are published in `Maven Central <https://repo1.maven.org/maven2/com/nablarch/>`_   
-. For the modules provided, see the `Module list <https://github.com/nablarch/nablarch/blob/main/README.md/>`_
+. For the modules provided, see the `Module list <https://github.com/nablarch/nablarch/>`_

--- a/en/biz_samples/01/index.rst
+++ b/en/biz_samples/01/index.rst
@@ -11,7 +11,7 @@ This is an implementation sample that performs authentication process using acco
 
   0101_PBKDF2PasswordEncryptor
 
-`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-password-authentication>`_
+`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-password-authentication>`_
 
 
 -------------------

--- a/en/biz_samples/03/index.rst
+++ b/en/biz_samples/03/index.rst
@@ -6,7 +6,7 @@ Display a List of Search Results
 
 This sample is an implementation sample of the tag file that displays a list of search results.
 
-`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-list-search-result>`_
+`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-list-search-result>`_
 
 -----------------
 Delivery package

--- a/en/biz_samples/04/index.rst
+++ b/en/biz_samples/04/index.rst
@@ -8,4 +8,4 @@ Extended Formatter Functions
   0401_ExtendedDataFormatter
   0402_ExtendedFieldType
   
-`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-formatter-extension>`_
+`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-formatter-extension>`_

--- a/en/biz_samples/05/index.rst
+++ b/en/biz_samples/05/index.rst
@@ -11,7 +11,7 @@ Summary
 
 Provides an implementation sample of the function to centrally manage the files used in business applications with DB.
 
-`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-db-file-management>`_
+`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-db-file-management>`_
 
 The sample is intended for the following applications:
 

--- a/en/biz_samples/08/index.rst
+++ b/en/biz_samples/08/index.rst
@@ -7,7 +7,7 @@ Summary
 
 Provides the implementation sample of the function that sends the HTML email.
 
-`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-html-mail>`_
+`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-html-mail>`_
 
 This function is a sample to send HTML mail using :ref:`mail` .
 Since this function is a sample implementation, the source code (both production and test code) must be imported into the project when using it in an implementation project.

--- a/en/biz_samples/09/index.rst
+++ b/en/biz_samples/09/index.rst
@@ -6,7 +6,7 @@ How to Use a Sample to Send a Digitally Signed Email Using Bouncycastle
 This chapter describes how to use the digitally signed send mail feature using bouncycastle. [#bouncy]_
 Since this function is a sample implementation, the source code (both production and test code) must be imported into the project when using it in an implementation project.
 
-`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-smime-integration>`_
+`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-smime-integration>`_
 
 .. [#bouncy]
   Bouncycastle is an open source library that provides security-related functions such as encryption.

--- a/en/biz_samples/10/index.rst
+++ b/en/biz_samples/10/index.rst
@@ -18,6 +18,6 @@ List of samples provided
 
   contents/OnlineAccessLogStatistics
   
-`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-statistics-report>`_
+`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-statistics-report>`_
 
 

--- a/en/biz_samples/11/index.rst
+++ b/en/biz_samples/11/index.rst
@@ -6,7 +6,7 @@ Messaging Platform Test Simulator Sample
   :depth: 3
   :local:
 
-`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-messaging-simulator>`_
+`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-messaging-simulator>`_
 
 This sample provides a sample implementation to simulate a destination system for testing applications using the Nablarch application framework  :ref:`mom_system_messaging` and :ref:`http_system_messaging`.
 

--- a/en/biz_samples/12/index.rst
+++ b/en/biz_samples/12/index.rst
@@ -7,7 +7,7 @@ Authentication sample using OIDC ID token
 Delivery package
 -----------------
 
-`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-oidc>`_
+`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-oidc>`_
 
 The sample is provided in the following package.
 

--- a/en/biz_samples/13/index.rst
+++ b/en/biz_samples/13/index.rst
@@ -3,7 +3,7 @@
 Sample Request/Response Log Output Using Logbook
 =====================================================
 
-`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-logbook>`_
+`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-logbook>`_
 
 --------------
 Summary

--- a/en/development_tools/java_static_analysis/index.rst
+++ b/en/development_tools/java_static_analysis/index.rst
@@ -45,7 +45,7 @@ We provide two tools for this check: the IntelliJ IDEA plugin and the SpotBugs p
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Use nablarch-intellij-plugin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-`nablarch-intellij-plugin <https://github.com/nablarch/nablarch-intellij-plugin/tree/master/en>`_  is a plugin to use IntelliJ IDEA for supporting Nablarch development and has the following functions.
+`nablarch-intellij-plugin <https://github.com/nablarch/nablarch-intellij-plugin/tree/main/en>`_  is a plugin to use IntelliJ IDEA for supporting Nablarch development and has the following functions.
 
 * Throws a warning if Nablarch private API is used.
 * Throws warning if Java API registered in the black list is used.

--- a/en/development_tools/testing_framework/guide/development_guide/05_UnitTestGuide/02_RequestUnitTest/batch.rst
+++ b/en/development_tools/testing_framework/guide/development_guide/05_UnitTestGuide/02_RequestUnitTest/batch.rst
@@ -218,7 +218,7 @@ Field name                 Describes the field name. Describes only the number o
 Data type                  Describes the data type of the field. Describes only the number of fields.
 
                            The data type is described with a Japanese name such as "half-width alphabets (半角英字)".\
-                           Refer to the member variable DEFAULT_TABLE of `BasicDataTypeMapping <https://github.com/nablarch/nablarch-testing/blob/master/src/main/java/nablarch/test/core/file/BasicDataTypeMapping.java>`_  for the mapping between data types in the format definition file and data types with Japanese names.
+                           Refer to the member variable DEFAULT_TABLE of `BasicDataTypeMapping <https://github.com/nablarch/nablarch-testing/blob/main/src/main/java/nablarch/test/core/file/BasicDataTypeMapping.java>`_  for the mapping between data types in the format definition file and data types with Japanese names.
 Field length               Describes the field type of the field. Describes only the number of fields.
 Data                       Describe the data stored in that field. If multiple records exist, the entry of data should be continued in the next line.
 ========================== ============================================================================================================================================================================================================================================================================================================

--- a/en/development_tools/testing_framework/guide/development_guide/05_UnitTestGuide/02_RequestUnitTest/send_sync.rst
+++ b/en/development_tools/testing_framework/guide/development_guide/05_UnitTestGuide/02_RequestUnitTest/send_sync.rst
@@ -172,7 +172,7 @@ Data type                  Describes the data type of the field. Describes only 
 
                            The data type is described with a Japanese name such as "half-width alphabets(半角英字)".
 
-                           Refer to the member variable DEFAULT_TABLE of `BasicDataTypeMapping <https://github.com/nablarch/nablarch-testing/blob/master/src/main/java/nablarch/test/core/file/BasicDataTypeMapping.java>`_ for the mapping between data types in the format definition file and data types with Japanese names.
+                           Refer to the member variable DEFAULT_TABLE of `BasicDataTypeMapping <https://github.com/nablarch/nablarch-testing/blob/main/src/main/java/nablarch/test/core/file/BasicDataTypeMapping.java>`_ for the mapping between data types in the format definition file and data types with Japanese names.
 Field length               Describes the field type of the field. Describes only the number of fields.
 Data                       Describe the data stored in that field.If multiple records exist, the entry of data should be continued in the next line.
                            Describe the data stored in that field.When the same request ID is sent synchronously multiple times in the same test case, the data is described following the next line.

--- a/en/development_tools/testing_framework/guide/development_guide/05_UnitTestGuide/03_DealUnitTest/send_sync.rst
+++ b/en/development_tools/testing_framework/guide/development_guide/05_UnitTestGuide/03_DealUnitTest/send_sync.rst
@@ -146,7 +146,7 @@ Data type                  Describes the data type of the field. Describes only 
 
                            The data type is described with a Japanese name such as "half-width alphabets(半角英字)".
 
-                           Refer to the member variable DEFAULT_TABLE of `BasicDataTypeMapping <https://github.com/nablarch/nablarch-testing/blob/master/src/main/java/nablarch/test/core/file/BasicDataTypeMapping.java>`_  for the mapping between data types in the format definition file and data types with Japanese names.
+                           Refer to the member variable DEFAULT_TABLE of `BasicDataTypeMapping <https://github.com/nablarch/nablarch-testing/blob/main/src/main/java/nablarch/test/core/file/BasicDataTypeMapping.java>`_  for the mapping between data types in the format definition file and data types with Japanese names.
 Field length               Describes the field type of the field. If "-" is specified, the size will be calculated automatically based on the description in the "Data" column.
                   
                            Describes only the number of fields.

--- a/ja/about_nablarch/mvn_module.rst
+++ b/ja/about_nablarch/mvn_module.rst
@@ -5,4 +5,4 @@ Nablarch のモジュール一覧
 ==================================================
 
 Nablarch のjava のオブジェクトコードおよびソースコードは、 `Maven Central <https://repo1.maven.org/maven2/com/nablarch/>`_ で公開しています。
-提供しているモジュールについては、 `モジュール一覧 <https://github.com/nablarch/nablarch/blob/master/README.md/>`_ をご覧ください。
+提供しているモジュールについては、 `モジュール一覧 <https://github.com/nablarch/nablarch/>`_ をご覧ください。

--- a/ja/biz_samples/01/index.rst
+++ b/ja/biz_samples/01/index.rst
@@ -11,7 +11,7 @@
 
   0101_PBKDF2PasswordEncryptor
 
-`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-password-authentication>`_
+`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-password-authentication>`_
 
 
 --------------

--- a/ja/biz_samples/03/index.rst
+++ b/ja/biz_samples/03/index.rst
@@ -6,7 +6,7 @@
 
 本サンプルは、検索結果の一覧表示を行うタグファイルの実装サンプルである。
 
-`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-list-search-result>`_
+`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-list-search-result>`_
 
 --------------
 提供パッケージ

--- a/ja/biz_samples/04/index.rst
+++ b/ja/biz_samples/04/index.rst
@@ -8,4 +8,4 @@
   0401_ExtendedDataFormatter
   0402_ExtendedFieldType
   
-`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-formatter-extension>`_
+`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-formatter-extension>`_

--- a/ja/biz_samples/05/index.rst
+++ b/ja/biz_samples/05/index.rst
@@ -10,7 +10,7 @@
 
 業務アプリケーションにて使用するファイルを、DBで一元管理するための機能の実装サンプルを提供する。
 
-`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-db-file-management>`_
+`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-db-file-management>`_
 
 本サンプルは以下の用途を想定している。
 

--- a/ja/biz_samples/08/index.rst
+++ b/ja/biz_samples/08/index.rst
@@ -7,7 +7,7 @@ HTMLメール送信機能サンプル
 
 HTMLメールを送信する機能の実装サンプルを提供する。
 
-`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-html-mail>`_
+`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-html-mail>`_
 
 本機能は、:ref:`メール送信機能<mail>` を使用してHTMLメールを送信するサンプルである。
 なお、本機能はサンプル実装のため、導入プロジェクトで使用する際には、ソースコード(プロダクション、テストコード共に）をプロジェクトに取り込み、使用すること。

--- a/ja/biz_samples/09/index.rst
+++ b/ja/biz_samples/09/index.rst
@@ -6,7 +6,7 @@ bouncycastleを使用した電子署名つきメールの送信サンプルの�
 本章では、bouncycastle\  [#bouncy]_\ を使用した電子署名付きメール送信機能の使用方法を解説する。
 なお、本機能はサンプル実装のため、導入プロジェクトで使用する際には、ソースコード(プロダクション、テストコード共に）をプロジェクトに取込使用すること。
 
-`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-smime-integration>`_
+`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-smime-integration>`_
 
 .. [#bouncy]
   bouncycastleとは、暗号化等のセキュリティ関連の機能を提供するオープンソースライブラリである。

--- a/ja/biz_samples/10/index.rst
+++ b/ja/biz_samples/10/index.rst
@@ -17,6 +17,6 @@
 
   contents/OnlineAccessLogStatistics
   
-`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-statistics-report>`_
+`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-statistics-report>`_
 
 

--- a/ja/biz_samples/11/index.rst
+++ b/ja/biz_samples/11/index.rst
@@ -6,7 +6,7 @@
   :depth: 3
   :local:
 
-`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-messaging-simulator>`_
+`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-messaging-simulator>`_
 
 本サンプルは、Nablarchアプリケーションフレームワークの :ref:`mom_system_messaging` 、 :ref:`http_system_messaging` を使用する
 アプリケーションのテストにて、対向先システムをシミュレートするサンプル実装を提供する。

--- a/ja/biz_samples/12/index.rst
+++ b/ja/biz_samples/12/index.rst
@@ -7,7 +7,7 @@ OIDCのIDトークンを用いた認証サンプル
 提供パッケージ
 --------------
 
-`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-oidc>`_
+`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-oidc>`_
 
 本サンプルは、以下のパッケージで提供される。
 

--- a/ja/biz_samples/13/index.rst
+++ b/ja/biz_samples/13/index.rst
@@ -3,7 +3,7 @@
 Logbookを用いたリクエスト/レスポンスログ出力サンプル
 =====================================================
 
-`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/master/nablarch-logbook>`_
+`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/main/nablarch-logbook>`_
 
 --------------
 概要

--- a/ja/development_tools/testing_framework/guide/development_guide/05_UnitTestGuide/02_RequestUnitTest/batch.rst
+++ b/ja/development_tools/testing_framework/guide/development_guide/05_UnitTestGuide/02_RequestUnitTest/batch.rst
@@ -228,7 +228,7 @@ SETUP_FIXED[グループID]=ファイルパス
 
                            データ型は「半角英字」のように日本語名称で記述する。
 
-                           フォーマット定義ファイル上のデータ型と日本語名称のデータ型のマッピングは、 `BasicDataTypeMapping <https://github.com/nablarch/nablarch-testing/blob/master/src/main/java/nablarch/test/core/file/BasicDataTypeMapping.java>`_ のメンバ変数DEFAULT_TABLEを参照。
+                           フォーマット定義ファイル上のデータ型と日本語名称のデータ型のマッピングは、 `BasicDataTypeMapping <https://github.com/nablarch/nablarch-testing/blob/main/src/main/java/nablarch/test/core/file/BasicDataTypeMapping.java>`_ のメンバ変数DEFAULT_TABLEを参照。
 フィールド長               そのフィールドのフィールド長を記載する。フィールドの数だけ記載する。
 データ                     そのフィールドに格納されるデータを記載する。複数レコード存在する場合は次の行に続けてデータを記載する。
 ========================== ===============================================================================================================================================================================================================================================================

--- a/ja/development_tools/testing_framework/guide/development_guide/05_UnitTestGuide/02_RequestUnitTest/send_sync.rst
+++ b/ja/development_tools/testing_framework/guide/development_guide/05_UnitTestGuide/02_RequestUnitTest/send_sync.rst
@@ -172,7 +172,7 @@ no                         ディレクティブ行の下の行には必ず「no
 
                            データ型は「半角英字」のように日本語名称で記述する。
 
-                           フォーマット定義ファイル上のデータ型と日本語名称のデータ型のマッピングは、 `BasicDataTypeMapping <https://github.com/nablarch/nablarch-testing/blob/master/src/main/java/nablarch/test/core/file/BasicDataTypeMapping.java>`_ のメンバ変数DEFAULT_TABLEを参照。
+                           フォーマット定義ファイル上のデータ型と日本語名称のデータ型のマッピングは、 `BasicDataTypeMapping <https://github.com/nablarch/nablarch-testing/blob/main/src/main/java/nablarch/test/core/file/BasicDataTypeMapping.java>`_ のメンバ変数DEFAULT_TABLEを参照。
 フィールド長               そのフィールドのフィールド長を記載する。フィールドの数だけ記載する。
 データ                     そのフィールドに格納されるデータを記載する。複数レコード存在する場合は次の行に続けてデータを記載する。
                            そのフィールドに格納されるデータを記載する。1テストケースにおいて同一リクエストIDで複数回同期送信する場合は、次の行に続けてデータを記載する。

--- a/ja/development_tools/testing_framework/guide/development_guide/05_UnitTestGuide/03_DealUnitTest/send_sync.rst
+++ b/ja/development_tools/testing_framework/guide/development_guide/05_UnitTestGuide/03_DealUnitTest/send_sync.rst
@@ -147,7 +147,7 @@ no                         ディレクティブ行の下の行には必ず「no
 
                            データ型は「半角英字」のように日本語名称で記述する。
 
-                           フォーマット定義ファイル上のデータ型と日本語名称のデータ型のマッピングは、 `BasicDataTypeMapping <https://github.com/nablarch/nablarch-testing/blob/master/src/main/java/nablarch/test/core/file/BasicDataTypeMapping.java>`_ のメンバ変数DEFAULT_TABLEを参照。
+                           フォーマット定義ファイル上のデータ型と日本語名称のデータ型のマッピングは、 `BasicDataTypeMapping <https://github.com/nablarch/nablarch-testing/blob/main/src/main/java/nablarch/test/core/file/BasicDataTypeMapping.java>`_ のメンバ変数DEFAULT_TABLEを参照。
 フィールド長               そのフィールドのフィールド長を記載する。「-」を記載した場合は、「データ」の欄の記載内容を元にサイズを自動計算する。
                   
                            フィールドの数だけ記載する。


### PR DESCRIPTION
nablarch organizationのデフォルトブランチをmasterからmainに変更するのに伴い、解説書内でmasterブランチを参照している箇所をmainブランチへの参照に変更した。

上記以外の変更点は以下の通り。
- ja/about_nablarch/mvn_module.rst 
  - 明示的にmasterブランチを指す必要がないので、urlからブランチ名削除