### PR TITLE
gsp-dba-maven-pluginリポジトリへのリンクを修正

### DIFF
--- a/en/application_framework/application_framework/blank_project/MavenModuleStructures/index.rst
+++ b/en/application_framework/application_framework/blank_project/MavenModuleStructures/index.rst
@@ -67,7 +67,7 @@ which is input during the project creation using nablarch-web-archetype and nabl
 
 .. tip::
 
-  Automatically generated entity is generated when `gsp-dba-maven-plugin(external site) <https://github.com/coastland/gsp-dba-maven-plugin>`_ is used.
+  Automatically generated entity is generated when `gsp-dba-maven-plugin(external site) <https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main/en>`_ is used.
   The configuration description in :doc:`../addin_gsp` is required to use the plugin.
 
 ----------------------------------
@@ -563,7 +563,7 @@ The following is configured respectively in each Maven project.
   *	JDBC driver
 * Configuration of the tools described in :ref:`firstStepBuiltInTools`. The following configurations are present.
 
-  * Database connection configuration used in `gsp-dba-maven-plugin(external site) <https://github.com/coastland/gsp-dba-maven-plugin>`_  (JDBC connection URL and database schema, etc.)
+  * Database connection configuration used in `gsp-dba-maven-plugin(external site) <https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main/en>`_  (JDBC connection URL and database schema, etc.)
   * Coverage configuration
 
 
@@ -740,7 +740,7 @@ The following are the policy of the recommended project configuration.
 
   Be careful not to duplicate resources when you split up a project.
 
-  For example, if you mix the edm files used by `gsp-dba-maven-plugin(external site) <https://github.com/coastland/gsp-dba-maven-plugin>`_ in multiple Maven projects,
+  For example, if you mix the edm files used by `gsp-dba-maven-plugin(external site) <https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main/en>`_ in multiple Maven projects,
   you will end up with duplicate entity classes in multiple Maven projects.
 
 .. _mavenModuleStructuresProblemsOfExcessivelyDivided:

--- a/en/application_framework/application_framework/blank_project/addin_gsp.rst
+++ b/en/application_framework/application_framework/blank_project/addin_gsp.rst
@@ -11,7 +11,7 @@ Initial Configuration Method of gsp-dba-maven-plugin (DBA Work Support Tool)
 Summary
 ====================================================
 
-`gsp-dba-maven-plugin(external site) <https://github.com/coastland/gsp-dba-maven-plugin>`_ is an open source tool provided under the Apache License Version 2.0 license.
+`gsp-dba-maven-plugin(external site) <https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main/en>`_ is an open source tool provided under the Apache License Version 2.0 license.
 
 gsp-dba-maven-plugin needs to be configured according to the RDBMS before starting the use.
 
@@ -19,7 +19,7 @@ This procedure shows the configuration method to use the gsp-dba-maven-plugin in
 
 .. important::
 
-  As described in `the README of the tool(external site) <https://github.com/coastland/gsp-dba-maven-plugin>`_ ,
+  As described in `the README of the tool(external site) <https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main/en>`_ ,
   gsp-dba-maven-plugin is intended for use in the development phase. The main target of this plugin is the local DB of developers.
   Using the plugin in a production environment is not recommended.
 
@@ -205,7 +205,7 @@ Also, a jar file containing the dump file is generated in the ``gsp-target/outpu
 
   If the execution fails, check if any restrictions specific to the RDBMS are violated.
 
-  For restrictions specific to the RDBMS, refer to "Common Goal Parameters" at https://github.com/coastland/gsp-dba-maven-plugin (external site).
+  For restrictions specific to the RDBMS, refer to "Common Goal Parameters" at `gsp-dba-maven-plugin(external site) <https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main/en>`_ .
 
 
 **2. Install the dump file to the local repository by executing the following command.**

--- a/en/application_framework/application_framework/blank_project/firstStep_appendix/firststep_complement.rst
+++ b/en/application_framework/application_framework/blank_project/firstStep_appendix/firststep_complement.rst
@@ -75,7 +75,7 @@ The following tools are included in projects generated from archetypes.
     - test
     - Configuration has been completed to the point where jacoco.exec is generated.
       jacoco.exec can be used with SonarQube and Jenkins plugins.
-  * - `Gsp-dba-maven-plugin (external site) <https://github.com/coastland/gsp-dba-maven-plugin>`_
+  * - `Gsp-dba-maven-plugin (external site) <https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main/en>`_
     - －
     - Launch with "mvn -P gsp gsp-dba:<Goal name>". For example, generate-ddl can be executed
       with "mvn-P gsp gsp-dba: generate-ddl".

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/setup_Java11.rst
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/setup_Java11.rst
@@ -62,7 +62,7 @@ Add dependent module used by gsp-dba-maven-plugin
 
 Configure by referring to the following.
 
-`Configuration in Java11 <https://github.com/coastland/gsp-dba-maven-plugin#java11%E3%81%A7%E3%81%AE%E8%A8%AD%E5%AE%9A>`_ (external site)
+`Configuration in Java11 <https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main/en#java11-configuration>`_ (external site)
 
 .. _setup_java11_jetty9:
 

--- a/en/application_framework/application_framework/blank_project/setup_blankProject/setup_Java17.rst
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/setup_Java17.rst
@@ -65,7 +65,7 @@ Configure gsp-dba-maven-plugin to work with Java 17
 
 Configure by referring to the following.
 
-`Configuration in Java17 <https://github.com/coastland/gsp-dba-maven-plugin#java17%E3%81%A7%E3%81%AE%E8%A8%AD%E5%AE%9A>`_ (external site)
+`Configuration in Java17 <https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main/en#java17-configuration>`_ (external site)
 
 .. _setup_java17_jetty9:
 

--- a/ja/application_framework/application_framework/blank_project/MavenModuleStructures/index.rst
+++ b/ja/application_framework/application_framework/blank_project/MavenModuleStructures/index.rst
@@ -69,7 +69,7 @@ nablarch-web-archetypeとnablarch-batch-archetypeのアーキタイプを使用�
 
 .. tip::
 
-  自動生成エンティティは `gsp-dba-maven-plugin(外部サイト) <https://github.com/coastland/gsp-dba-maven-plugin>`_ を使用した場合に生成される。
+  自動生成エンティティは `gsp-dba-maven-plugin(外部サイト) <https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main>`_ を使用した場合に生成される。
   使用する場合は、:doc:`../addin_gsp` に記載されている設定を行う必要がある。
 
 
@@ -569,7 +569,7 @@ DBに接続しないNablarchバッチアプリケーションがデプロイさ�
   * JDBCドライバ
 * :ref:`firstStepBuiltInTools` に記載されているツールの設定。以下のような設定が存在する。
   
-  * `gsp-dba-maven-plugin(外部サイト) <https://github.com/coastland/gsp-dba-maven-plugin>`_ で使用するデータベース接続設定（JDBC接続URLやデータベーススキーマなど）
+  * `gsp-dba-maven-plugin(外部サイト) <https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main>`_ で使用するデータベース接続設定（JDBC接続URLやデータベーススキーマなど）
   * カバレッジ設定 
 
 
@@ -747,7 +747,7 @@ Nablarchのライブラリの場合、pom.xmlにバージョン番号は通常�
 
   プロジェクトを分割する際には、リソースの重複が無い様に注意すること。
 
-  例えば、`gsp-dba-maven-plugin(外部サイト) <https://github.com/coastland/gsp-dba-maven-plugin>`_ で使用するedmファイルを複数のMavenプロジェクトに混在させると、重複したEntityクラスが複数のMavenプロジェクトに存在することになる。
+  例えば、`gsp-dba-maven-plugin(外部サイト) <https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main>`_ で使用するedmファイルを複数のMavenプロジェクトに混在させると、重複したEntityクラスが複数のMavenプロジェクトに存在することになる。
 
 
 .. _mavenModuleStructuresProblemsOfExcessivelyDivided:

--- a/ja/application_framework/application_framework/blank_project/addin_gsp.rst
+++ b/ja/application_framework/application_framework/blank_project/addin_gsp.rst
@@ -11,7 +11,7 @@ gsp-dba-maven-plugin(DBA作業支援ツール)の初期設定方法
 概要
 ====================================================
 
-`gsp-dba-maven-plugin(外部サイト) <https://github.com/coastland/gsp-dba-maven-plugin>`_ は、Apache License Version 2.0 ライセンスで提供されるオープンソースのツールである。
+`gsp-dba-maven-plugin(外部サイト) <https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main>`_ は、Apache License Version 2.0 ライセンスで提供されるオープンソースのツールである。
 
 gsp-dba-maven-pluginは、使用開始前にRDBMSにあわせて設定する必要がある。
 
@@ -19,7 +19,7 @@ gsp-dba-maven-pluginは、使用開始前にRDBMSにあわせて設定する必�
 
 .. important::
 
-  `ツールのREADME(外部サイト) <https://github.com/coastland/gsp-dba-maven-plugin>`_ にもある通り、gsp-dba-maven-pluginは開発フェーズで用いることを想定している。
+  `ツールのREADME(外部サイト) <https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main>`_ にもある通り、gsp-dba-maven-pluginは開発フェーズで用いることを想定している。
   開発者のローカルDBを主ターゲットとしたツールであり、本番環境での使用は推奨しない。
 
   ER図からツールによって生成されたDDLをそのまま本番環境に配置して実行するというような使い方も想定していない。
@@ -204,7 +204,7 @@ src/main/resources/entity以下にRDBMS毎にedmファイルが存在するの�
 
   実行に失敗する場合は、RDBMS固有の制限事項に抵触していないか確認する。
   
-  RDBMS固有の制限事項については、https://github.com/coastland/gsp-dba-maven-plugin (外部サイト)の「ゴール共通のパラメータ」を参照。
+  RDBMS固有の制限事項については、`gsp-dba-maven-plugin(外部サイト) <https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main>`_ の「ゴール共通のパラメータ」を参照。
 
 
 **2.以下のコマンドを実行して、ダンプファイルをローカルリポジトリへインストールする。**

--- a/ja/application_framework/application_framework/blank_project/firstStep_appendix/firststep_complement.rst
+++ b/ja/application_framework/application_framework/blank_project/firstStep_appendix/firststep_complement.rst
@@ -76,7 +76,7 @@ Password      ``SAMPLE``
     - test
     - jacoco.execが生成されるところまで設定済み。|br|
       jacoco.execは、SonarQube及びJenkinsのプラグインで使用出来る。
-  * - `gsp-dba-maven-plugin(外部サイト) <https://github.com/coastland/gsp-dba-maven-plugin>`_
+  * - `gsp-dba-maven-plugin(外部サイト) <https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main>`_
     - －
     - 起動は、「mvn -P gsp gsp-dba:<ゴール名>」で行う。|br|
       例えば、「mvn -P gsp gsp-dba:generate-ddl」でgenerate-ddlを実行できる。

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Java11.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Java11.rst
@@ -62,7 +62,7 @@ gsp-dba-maven-pluginが使用する依存モジュールの追加
 
 以下を参照して設定する。
 
-`Java 11 での設定 <https://github.com/coastland/gsp-dba-maven-plugin#java11%E3%81%A7%E3%81%AE%E8%A8%AD%E5%AE%9A>`_ (外部サイト)
+`Java 11 での設定 <https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main?tab=readme-ov-file#java11%E3%81%A7%E3%81%AE%E8%A8%AD%E5%AE%9A>`_ (外部サイト)
 
 .. _setup_java11_jetty9:
 

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Java17.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Java17.rst
@@ -65,7 +65,7 @@ gsp-dba-maven-pluginがJava17で動くように設定する
 
 以下を参照して設定する。
 
-`Java 17 での設定 <https://github.com/coastland/gsp-dba-maven-plugin#java17%E3%81%A7%E3%81%AE%E8%A8%AD%E5%AE%9A>`_ (外部サイト)
+`Java 17 での設定 <https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main?tab=readme-ov-file#java17%E3%81%A7%E3%81%AE%E8%A8%AD%E5%AE%9A>`_ (外部サイト)
 
 .. _setup_java17_jetty9:
 


### PR DESCRIPTION
# 概要

gsp-dba-maven-pluginのJava 17向けの設定の案内で、gps-dba-maven-pluginリポジトリへのページ内リンクが5系と4系の入れ替えにより機能しなくなっていたので、全体的に以下のように修正。

- https://github.com/coastland/gsp-dba-maven-plugin へのリンクを https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main に変更
- 英語版の場合は https://github.com/coastland/gsp-dba-maven-plugin/tree/4.x.x-main/en に変更
- Java 17だけではなく、Java 11もページ内リンクが機能しなくなっていたので合わせて修正

Nablarch 5の解説書からgsp-dba-maven-pluginの5系を案内されても困るので、4系を案内するように見直しました。 
URLを直接記載していた箇所については、リンクテキスト表現になるように修正しています。