### PR TITLE
gsp-dba-maven-plugin をlinkcheck_ignoreから除外

### DIFF
--- a/ja/conf.py
+++ b/ja/conf.py
@@ -210,7 +210,6 @@ htmlhelp_basename = 'Nablarchdoc'
 
 # -- Options for linkcheck ----------------------------------------------
 linkcheck_ignore = [
-   'https://github.com/coastland/gsp-dba-maven-plugin#',
    'http://localhost',
    'http://127.0.0.1',
    'http://tis.co.jp/nablarch'


### PR DESCRIPTION
`https://github.com/coastland/gsp-dba-maven-plugin#` から始まるリンクがドキュメント内に存在しなかったため、https://github.com/coastland/gsp-dba-maven-plugin#sample 等のダミーのリンクを追加し、以下の内容を確認済

- 修正前はignoreとしてチェックの対象外になること
- 修正後はbrokenとして検知されること