### PR TITLE
gsp-dba-maven-plugin をlinkcheck_ignoreから除外（5系）

### DIFF
--- a/en/conf.py
+++ b/en/conf.py
@@ -210,7 +210,6 @@ htmlhelp_basename = 'Nablarchdoc'
 
 # -- Options for linkcheck ----------------------------------------------
 linkcheck_ignore = [
-   'https://github.com/coastland/gsp-dba-maven-plugin#',
    'http://localhost',
    'http://127.0.0.1',
    'http://tis.co.jp/nablarch'

--- a/ja/conf.py
+++ b/ja/conf.py
@@ -210,7 +210,6 @@ htmlhelp_basename = 'Nablarchdoc'
 
 # -- Options for linkcheck ----------------------------------------------
 linkcheck_ignore = [
-   'https://github.com/coastland/gsp-dba-maven-plugin#',
    'http://localhost',
    'http://127.0.0.1',
    'http://tis.co.jp/nablarch'


### PR DESCRIPTION
https://github.com/nablarch/nablarch-document/pull/657 の5系対応