### PR TITLE
Dockerfile内のnpm install時にパッチが適用されるように修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /root
 
 COPY requirements.txt /root/
 COPY package*.json /root/
+COPY patches /root/patches/
 
 # Sphinxのセットアップ
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
# 概要

textlintを実行する際に、ファイルサイズの大きいドキュメント（具体的には`ja/application_framework/application_framework/libraries/tag.rst`）をtextlint-plugin-rstが解析できずに失敗していた。

```shell
/root/document/ja/application_framework/application_framework/libraries/tag.rst
  1:0  error  Failed to parse text by plugin: rst

Please report this error with the content to plugin author.

Error: spawnSync /bin/sh ENOBUFS
    at Object.spawnSync (node:internal/child_process:1119:20)
    at spawnSync (node:child_process:847:24)
    at execSync (node:child_process:927:15)
    at parse (/root/node_modules/textlint-plugin-rst/lib/rst-to-ast.js:38:54)
    at preProcess (/root/node_modules/textlint-plugin-rst/lib/ReSTProcessor.js:25:48)
    at /root/node_modules/@textlint/kernel/lib/src/util/parse-by-plugin.js:23:40
    at Generator.next (<anonymous>)
    at /root/node_modules/@textlint/kernel/lib/src/util/parse-by-plugin.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/root/node_modules/@textlint/kernel/lib/src/util/parse-by-plugin.js:4:12)
  plugin-error

✖ 1 problem (1 error, 0 warnings)
```

これにパッチを適用する修正。

パッチ自体はすでに作成してあり、textlintを実行するためのDockerコンテナの定義に取り込めていなかったので、その修正。

# 動作確認

修正した`Dockerfile`を使って作成したイメージで、textlintが実行可能になっていることを確認。