### PR TITLE
EntityResponseをジェネリクスに対応

### DIFF
--- a/ja/application_framework/application_framework/web_service/rest/feature_details/resource_signature.rst
+++ b/ja/application_framework/application_framework/web_service/rest/feature_details/resource_signature.rst
@@ -229,12 +229,12 @@ Producesアノテーションを使用し、リソースクラスのメソッド
   .. code-block:: java
 
     @Produces(MediaType.APPLICATION_JSON)
-    public EntityResponse something(JaxRsHttpRequest request, ExecutionContext context) {
+    public EntityResponse<List<Client>> something(JaxRsHttpRequest request, ExecutionContext context) {
 
         // 処理は省略
         List<Client> clients = service.findClients(condition);
 
-        EntityResponse response = new EntityResponse();
+        EntityResponse<List<Client>> response = new EntityResponse<>();
         response.setEntity(clients); // エンティティを指定
         response.setStatusCode(HttpResponse.Status.OK.getStatusCode()); // ステータスコードを指定
         response.setHeader("Cache-Control", "no-store"); // レスポンスヘッダを指定


### PR DESCRIPTION
https://github.com/nablarch/nablarch-fw-jaxrs/pull/43 のドキュメント反映版。

`EntityResponse`をジェネリクスに対応させたので、コード例を追従させた。  
`EntityResponse`にフォーカスした説明は特に追加しなくてよいと考える。