### PR TITLE
Jakarta RESTful Web ServicesアダプタのJersey、RESTEasyのJSONコンバータにDate and Time APIのサポートを追加

### DIFF
--- a/ja/application_framework/adaptors/jaxrs_adaptor.rst
+++ b/ja/application_framework/adaptors/jaxrs_adaptor.rst
@@ -115,8 +115,7 @@ RESTEasy環境下でRESTfulウェブサービスを使用する
 
 * :ref:`body_convert_handler` の設定(以下のコンバータが設定される)
 
-  * JSONのコンバータには :java:extdoc:`Jackson2BodyConverter <nablarch.integration.jaxrs.jackson.Jackson2BodyConverter>` が設定される.
-
+  * JSONのコンバータには :java:extdoc:`Jackson2BodyConverter <nablarch.integration.jaxrs.jackson.Jackson2BodyConverter>` が設定される。
   * XMLのコンバータには :java:extdoc:`JaxbBodyConverter <nablarch.fw.jaxrs.JaxbBodyConverter>` が設定される。
   * application/x-www-form-urlencodedのコンバータには :java:extdoc:`FormUrlEncodedConverter <nablarch.fw.jaxrs.FormUrlEncodedConverter>` が設定される。
 

--- a/ja/application_framework/adaptors/jaxrs_adaptor.rst
+++ b/ja/application_framework/adaptors/jaxrs_adaptor.rst
@@ -73,9 +73,13 @@ Jersey環境下でRESTfulウェブサービスを使用する
 
 * :ref:`body_convert_handler` の設定(以下のコンバータが設定される)
 
-  * JSONのコンバータには :java:extdoc:`Jackson2BodyConverter <nablarch.integration.jaxrs.jackson.Jackson2BodyConverter>` が設定される。
+  * JSONのコンバータには :java:extdoc:`Jackson2BodyConverter <nablarch.integration.jaxrs.jackson.Jackson2BodyConverter>` にDate and Time APIを使用できるように拡張したクラスが設定される。
   * XMLのコンバータには :java:extdoc:`JaxbBodyConverter <nablarch.fw.jaxrs.JaxbBodyConverter>` が設定される。
   * application/x-www-form-urlencodedのコンバータには :java:extdoc:`FormUrlEncodedConverter <nablarch.fw.jaxrs.FormUrlEncodedConverter>` が設定される。
+
+.. tip::
+
+  JSONのコンバータでDate and Time APIを使用するために、 `jackson-modules-java8(外部サイト、英語) <https://github.com/FasterXML/jackson-modules-java8>`_ に含まれるJava 8 Date/timeモジュールを追加している。
 
 * :ref:`jaxrs_bean_validation_handler`
 
@@ -111,9 +115,13 @@ RESTEasy環境下でRESTfulウェブサービスを使用する
 
 * :ref:`body_convert_handler` の設定(以下のコンバータが設定される)
 
-  * JSONのコンバータには :java:extdoc:`Jackson2BodyConverter <nablarch.integration.jaxrs.jackson.Jackson2BodyConverter>` が設定される。
+  * JSONのコンバータには :java:extdoc:`Jackson2BodyConverter <nablarch.integration.jaxrs.jackson.Jackson2BodyConverter>` にDate and Time APIを使用できるように拡張したクラスが設定される。
   * XMLのコンバータには :java:extdoc:`JaxbBodyConverter <nablarch.fw.jaxrs.JaxbBodyConverter>` が設定される。
   * application/x-www-form-urlencodedのコンバータには :java:extdoc:`FormUrlEncodedConverter <nablarch.fw.jaxrs.FormUrlEncodedConverter>` が設定される。
+
+.. tip::
+
+  JSONのコンバータでDate and Time APIを使用するために、 `jackson-modules-java8(外部サイト、英語) <https://github.com/FasterXML/jackson-modules-java8>`_ に含まれるJava 8 Date/timeモジュールを追加している。
 
 * :ref:`jaxrs_bean_validation_handler`
 

--- a/ja/application_framework/adaptors/jaxrs_adaptor.rst
+++ b/ja/application_framework/adaptors/jaxrs_adaptor.rst
@@ -73,13 +73,13 @@ Jersey環境下でRESTfulウェブサービスを使用する
 
 * :ref:`body_convert_handler` の設定(以下のコンバータが設定される)
 
-  * JSONのコンバータには :java:extdoc:`Jackson2BodyConverter <nablarch.integration.jaxrs.jackson.Jackson2BodyConverter>` にDate and Time APIを使用できるように拡張したクラスが設定される。
+  * JSONのコンバータには :java:extdoc:`Jackson2BodyConverter <nablarch.integration.jaxrs.jackson.Jackson2BodyConverter>` が設定される。
   * XMLのコンバータには :java:extdoc:`JaxbBodyConverter <nablarch.fw.jaxrs.JaxbBodyConverter>` が設定される。
   * application/x-www-form-urlencodedのコンバータには :java:extdoc:`FormUrlEncodedConverter <nablarch.fw.jaxrs.FormUrlEncodedConverter>` が設定される。
 
 .. tip::
 
-  JSONのコンバータでDate and Time APIを使用するために、 `jackson-modules-java8(外部サイト、英語) <https://github.com/FasterXML/jackson-modules-java8>`_ に含まれるJava 8 Date/timeモジュールを追加している。
+  JSONのコンバータには、Date and Time APIを使用するために `jackson-modules-java8(外部サイト、英語) <https://github.com/FasterXML/jackson-modules-java8>`_ に含まれるJava 8 Date/timeモジュールの追加および設定を行っている。
 
 * :ref:`jaxrs_bean_validation_handler`
 
@@ -115,13 +115,14 @@ RESTEasy環境下でRESTfulウェブサービスを使用する
 
 * :ref:`body_convert_handler` の設定(以下のコンバータが設定される)
 
-  * JSONのコンバータには :java:extdoc:`Jackson2BodyConverter <nablarch.integration.jaxrs.jackson.Jackson2BodyConverter>` にDate and Time APIを使用できるように拡張したクラスが設定される。
+  * JSONのコンバータには :java:extdoc:`Jackson2BodyConverter <nablarch.integration.jaxrs.jackson.Jackson2BodyConverter>` が設定される.
+
   * XMLのコンバータには :java:extdoc:`JaxbBodyConverter <nablarch.fw.jaxrs.JaxbBodyConverter>` が設定される。
   * application/x-www-form-urlencodedのコンバータには :java:extdoc:`FormUrlEncodedConverter <nablarch.fw.jaxrs.FormUrlEncodedConverter>` が設定される。
 
 .. tip::
 
-  JSONのコンバータでDate and Time APIを使用するために、 `jackson-modules-java8(外部サイト、英語) <https://github.com/FasterXML/jackson-modules-java8>`_ に含まれるJava 8 Date/timeモジュールを追加している。
+  JSONのコンバータには、Date and Time APIを使用するために `jackson-modules-java8(外部サイト、英語) <https://github.com/FasterXML/jackson-modules-java8>`_ に含まれるJava 8 Date/timeモジュールの追加および設定を行っている。
 
 * :ref:`jaxrs_bean_validation_handler`
 


### PR DESCRIPTION
https://github.com/nablarch/nablarch-jaxrs-adaptor/pull/48 のドキュメントへの反映。

修正方針は以下としました。

- `JerseyJackson2BodyConverter`、`ResteasyJackson2BodyConverter`は`@Published`ではないので、「Date and Time APIを使用できるように拡張したクラス」という表現にした（クラス名とJavadocへのリンクは明記しない）
- 上記のままだと具体性に乏しいので、 `tip::` で具体的に追加したモジュールについて補足