### PR TITLE
システムリポジトリ: サンプルコードのXML閉じ誤りを修正

### DIFF
--- a/en/application_framework/application_framework/libraries/repository.rst
+++ b/en/application_framework/application_framework/libraries/repository.rst
@@ -123,7 +123,7 @@ An example is shown below.
 
     <!-- Setter injection of literal value -->
     <property name="limit" value="100" />
-  <component/>
+  </component>
 
 
 .. important::

--- a/ja/application_framework/application_framework/libraries/repository.rst
+++ b/ja/application_framework/application_framework/libraries/repository.rst
@@ -122,7 +122,7 @@ Java Beansオブジェクトは、component要素を用いて定義する。
 
     <!-- リテラル値をsetterインジェクションする -->
     <property name="limit" value="100" />
-  <component/>
+  </component>
 
 
 .. important::


### PR DESCRIPTION
## before
XMLのタグが閉じていないので、無効なExamp　leになっていた。

![image](https://github.com/user-attachments/assets/82f202a1-a498-49ec-af50-f3100f4e9cb0)

## after
タグが閉じている。

![image](https://github.com/user-attachments/assets/222ab434-8101-4c07-9ed5-01ff732056ae)

