### PR TITLE
存在しない項目(information)を設定例から削除

### DIFF
--- a/ja/application_framework/application_framework/libraries/log.rst
+++ b/ja/application_framework/application_framework/libraries/log.rst
@@ -766,7 +766,7 @@ LogWriterで使用するフォーマッタを :java:extdoc:`JsonLogFormatter <na
   writer.appLog.formatter.className=nablarch.core.log.basic.JsonLogFormatter
  
   # 出力項目を指定する。
-  writer.appLog.formatter.targets=date,logLevel,message,information,stackTrace
+  writer.appLog.formatter.targets=date,logLevel,message,stackTrace
  
   # 日時のフォーマットに使用するパターンを指定する。
   # 指定しなければ"yyyy-MM-dd HH:mm:ss.SSS"となる。


### PR DESCRIPTION
https://nablarch.github.io/docs/LATEST/doc/application_framework/application_framework/libraries/log.html#logwriterjsonlogformatter に記載されている設定例を試すと例外がスローされました。

```
[CONTAINER] lina.core.ContainerBase.[Catalina].[localhost].[/] SEVERE  Error configuring application listener of class [nablarch.fw.web.servlet.NablarchServletContextListener]
java.lang.ExceptionInInitializerError
        at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized0(Native Method)
        at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized(Unknown Source)
        at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.ensureClassInitialized(Unknown Source)
        at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.newConstructorAccessor(Unknown Source)
        at java.base/jdk.internal.reflect.ReflectionFactory.newConstructorAccessor(Unknown Source)
        at java.base/java.lang.reflect.Constructor.acquireConstructorAccessor(Unknown Source)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Unknown Source)
        at java.base/java.lang.reflect.Constructor.newInstance(Unknown Source)
        at org.apache.catalina.core.DefaultInstanceManager.newInstance(DefaultInstanceManager.java:144)
        at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:3935)
        at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:4436)
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:164)
        at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:599)
        at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:571)
        at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:654)
        at org.apache.catalina.startup.HostConfig.deployDirectory(HostConfig.java:1130)
        at org.apache.catalina.startup.HostConfig$DeployDirectory.run(HostConfig.java:1933)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
        at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
        at org.apache.tomcat.util.threads.InlineExecutorService.execute(InlineExecutorService.java:75)
        at java.base/java.util.concurrent.AbstractExecutorService.submit(Unknown Source)
        at org.apache.catalina.startup.HostConfig.deployDirectories(HostConfig.java:1041)
        at org.apache.catalina.startup.HostConfig.deployApps(HostConfig.java:425)
        at org.apache.catalina.startup.HostConfig.start(HostConfig.java:1629)
        at org.apache.catalina.startup.HostConfig.lifecycleEvent(HostConfig.java:303)
        at org.apache.catalina.util.LifecycleBase.fireLifecycleEvent(LifecycleBase.java:109)
        at org.apache.catalina.util.LifecycleBase.setStateInternal(LifecycleBase.java:389)
        at org.apache.catalina.util.LifecycleBase.setState(LifecycleBase.java:336)
        at org.apache.catalina.core.ContainerBase.startInternal(ContainerBase.java:776)
        at org.apache.catalina.core.StandardHost.startInternal(StandardHost.java:772)
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:164)
        at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1203)
        at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1193)
        at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
        at org.apache.tomcat.util.threads.InlineExecutorService.execute(InlineExecutorService.java:75)
        at java.base/java.util.concurrent.AbstractExecutorService.submit(Unknown Source)
        at org.apache.catalina.core.ContainerBase.startInternal(ContainerBase.java:749)
        at org.apache.catalina.core.StandardEngine.startInternal(StandardEngine.java:203)
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:164)
        at org.apache.catalina.core.StandardService.startInternal(StandardService.java:415)
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:164)
        at org.apache.catalina.core.StandardServer.startInternal(StandardServer.java:870)
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:164)
        at org.apache.catalina.startup.Catalina.start(Catalina.java:761)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
        at java.base/java.lang.reflect.Method.invoke(Unknown Source)
        at org.apache.catalina.startup.Bootstrap.start(Bootstrap.java:345)
        at org.apache.catalina.startup.Bootstrap.main(Bootstrap.java:473)
Caused by: java.lang.IllegalArgumentException: JsonLogFormatter : [information] is unknown target. property name = [writer.stdout.formatter.targets]
        at nablarch.core.log.basic.JsonLogFormatter.createStructuredTargets(JsonLogFormatter.java:208)
        at nablarch.core.log.basic.JsonLogFormatter.initialize(JsonLogFormatter.java:151)
        at nablarch.core.log.basic.LogWriterSupport.initialize(LogWriterSupport.java:71)
        at nablarch.core.log.basic.BasicLoggerFactory.createLogWriter(BasicLoggerFactory.java:245)
        at nablarch.core.log.basic.BasicLoggerFactory.createWriters(BasicLoggerFactory.java:171)
        at nablarch.core.log.basic.BasicLoggerFactory.initialize(BasicLoggerFactory.java:93)
        at nablarch.core.log.LoggerManager$1.create(LoggerManager.java:44)
        at nablarch.core.log.LoggerManager$1.create(LoggerManager.java:39)
        at nablarch.core.log.LogUtil.getObjectBoundToClassLoader(LogUtil.java:441)
        at nablarch.core.log.LoggerManager.get(LoggerManager.java:90)
        at nablarch.core.log.LoggerManager.get(LoggerManager.java:75)
        at nablarch.fw.web.servlet.NablarchServletContextListener.<clinit>(NablarchServletContextListener.java:35)
        ... 48 more
```

メッセージを見ると`information`は不明なターゲットとのことだったので設定例から削除しました。