### PR TITLE
初期化が必要なのにも関わらず、初期化についての案内がないコンポーネントに対して設定例を追加

### DIFF
--- a/en/application_framework/adaptors/webspheremq_adaptor.rst
+++ b/en/application_framework/adaptors/webspheremq_adaptor.rst
@@ -31,6 +31,7 @@ The adapter is enabled by defining components with the following procedure.
 
 1. Add the definition of ``nablarch.integration.messaging.wmq.provider.WmqMessagingProvider`` to the component configuration file.
 2. Configure ``WmqMessagingProvider`` configured in ``1`` to :ref:`messaging_context_handler` .
+3. Configure ``WmqMessagingProvider`` configured in ``1`` in the list of initialization targets as it needs to be initialized.
 
 A configuration example is shown below.
 
@@ -49,6 +50,16 @@ A configuration example is shown below.
   -->
   <component class="nablarch.fw.messaging.handler.MessagingContextHandler">
     <property name="messagingProvider" ref="wmqMessagingProvider" />
+  </component>
+
+  <component name="initializer"
+      class="nablarch.core.repository.initialization.BasicApplicationInitializer">
+    <property name="initializeList">
+      <list>
+        <!-- Initialize WmqMessagingProvider -->
+        <component-ref name="wmqMessagingProvider" />
+      </list>
+    </property>
   </component>
 
 Use distributed transaction

--- a/en/application_framework/application_framework/handlers/standalone/process_stop_handler.rst
+++ b/en/application_framework/application_framework/handlers/standalone/process_stop_handler.rst
@@ -66,6 +66,7 @@ A configuration example is shown below.
 Point
   * When used in the On-demand batch, configure this handler on the subthread.
   * Configure this handler on the main thread when used in the resident batch.
+  * Configure this handler in the list of initialization targets as it needs to be initialized.
 
 .. code-block:: xml
 
@@ -83,4 +84,14 @@ Point
 
     <!-- Exit code when the process is stopped (optional) -->
     <property name="exitCode" value="50" />
+  </component>
+
+  <component name="initializer"
+      class="nablarch.core.repository.initialization.BasicApplicationInitializer">
+    <property name="initializeList">
+      <list>
+        <!-- Other components are omitted -->
+        <component-ref name="processStopHandler" />
+      </list>
+    </property>
   </component>

--- a/en/application_framework/application_framework/libraries/code.rst
+++ b/en/application_framework/application_framework/libraries/code.rst
@@ -145,7 +145,7 @@ Configuration file example
   Point
     * Set the component name of  :java:extdoc:`BasicCodeManager <nablarch.common.code.BasicCodeManager>`  to  **codeManager** .    
     * Refer to  :ref:`static_data_cache-cache_timing`  for configuration value of :java:extdoc:`loadOnStartup <nablarch.core.cache.BasicStaticDataCache.setLoadOnStartup(boolean)>` of  :java:extdoc:`BasicStaticDataCache <nablarch.core.cache.BasicStaticDataCache>` .
-    * Configure :java:extdoc:`BasicStaticDataCache <nablarch.core.cache.BasicStaticDataCache>`  in the list of initialization targets as it needs to be initialized.
+    * Configure :java:extdoc:`BasicCodeLoader <nablarch.common.code.BasicCodeLoader>` and :java:extdoc:`BasicStaticDataCache <nablarch.core.cache.BasicStaticDataCache>`  in the initialization list as they require initialization.
 
   .. code-block:: xml
 
@@ -178,12 +178,12 @@ Configuration file example
       <property name="codeDefinitionCache" ref="codeCache"/>
     </component>
 
-    <!-- Configure BasicStaticDataCache in the initialization list as it requires
-    to be initialized -->
+    <!-- Configure BasicCodeLoader and BasicStaticDataCache in the initialization list as they require initialization -->
     <component name="initializer"
         class="nablarch.core.repository.initialization.BasicApplicationInitializer">
       <property name="initializeList">
         <list>
+          <component-ref name="codeLoader"/>
           <component-ref name="codeCache"/>
         </list>
       </property>

--- a/en/application_framework/application_framework/libraries/database/generator.rst
+++ b/en/application_framework/application_framework/libraries/database/generator.rst
@@ -92,6 +92,13 @@ If the numbering function (automatic numbering column) of the database is used w
 
 .. code-block:: xml
 
+  <!-- Configuration of table numbering module -->
+  <component name="tableIdGenerator" class="nablarch.common.idgenerator.TableIdGenerator">
+    <property name="tableName" value="GENERATOR" />
+    <property name="idColumnName" value="ID" />
+    <property name="noColumnName" value="NO" />
+  </component>
+
   <component name="daoContextFactory" class="nablarch.common.dao.BasicDaoContextFactory">
     <!-- Configuration of sequence numbering -->
     <property name="sequenceIdGenerator">
@@ -99,15 +106,19 @@ If the numbering function (automatic numbering column) of the database is used w
     </property>
 
     <!-- Configuration of table numbering -->
-    <property name="tableIdGenerator">
-      <component class="nablarch.common.idgenerator.TableIdGenerator">
-          <property name="tableName" value="GENERATOR" />
-          <property name="idColumnName" value="ID" />
-          <property name="noColumnName" value="NO" />
-      </component>
-    </property>
+    <property name="tableIdGenerator" ref="tableIdGenerator" />
 
     <!-- Skip configuration that are not required for numbering -->
+  </component>
+
+  <component name="initializer"
+      class="nablarch.core.repository.initialization.BasicApplicationInitializer">
+    <property name="initializeList">
+      <list>
+        <!-- TableIdGenerator requires initialization -->
+        <component-ref name="tableIdGenerator" />
+      </list>
+    </property>
   </component>
 
 Expansion example

--- a/en/application_framework/application_framework/libraries/date.rst
+++ b/en/application_framework/application_framework/libraries/date.rst
@@ -69,6 +69,8 @@ To use the business date management function,
 add :java:extdoc:`BasicBusinessDateProvider <nablarch.core.date.BasicBusinessDateProvider>` configuration to the component definition. 
 Specify the component name as  **businessDateProvider**.
 
+Also, since initialization is required, set it in the list to be initialized.
+
 .. code-block:: xml
 
  <component name="businessDateProvider" class="nablarch.core.date.BasicBusinessDateProvider">
@@ -82,6 +84,16 @@ Specify the component name as  **businessDateProvider**.
    <property name="defaultSegment" value="00"/>
    <!-- Transaction manager used for database access -->
    <property name="transactionManager" ref="transactionManager" />
+ </component>
+
+ <component name="initializer"
+     class="nablarch.core.repository.initialization.BasicApplicationInitializer">
+   <property name="initializeList">
+     <list>
+       <!-- Other components are omitted -->
+       <component-ref name="businessDateProvider" />
+     </list>
+   </property>
  </component>
 
 Acquire business date

--- a/en/application_framework/application_framework/libraries/mail.rst
+++ b/en/application_framework/application_framework/libraries/mail.rst
@@ -667,3 +667,13 @@ A configuration example for this case is shown below.
       <!-- Specify the transaction name specified in the transaction manager  -->
       <property name="dbTransactionName" value="mail-transaction" />
   </component>
+
+  <component name="initializer"
+      class="nablarch.core.repository.initialization.BasicApplicationInitializer">
+    <property name="initializeList">
+      <list>
+        <!-- TableIdGenerator requires initialization -->
+        <component-ref name="mailRequestIdGenerator" />
+      </list>
+    </property>
+  </component>

--- a/en/application_framework/application_framework/libraries/service_availability.rst
+++ b/en/application_framework/application_framework/libraries/service_availability.rst
@@ -69,6 +69,8 @@ To use the service availability check,
 add the definition of :java:extdoc:`BasicServiceAvailability <nablarch.common.availability.BasicServiceAvailability>` to the component configuration file.
 Specify the component name as **serviceAvailability**.
 
+Also, since initialization is required, set it in the list to be initialized.
+
 .. code-block:: xml
 
  <component name="serviceAvailability" class="nablarch.common.availability.BasicServiceAvailability">
@@ -82,6 +84,16 @@ Specify the component name as **serviceAvailability**.
    <property name="requestTableServiceAvailableOkStatus" value="1"/>
    <!-- Transaction manager used for database access -->
    <property name="dbManager" ref="serviceAvailabilityDbManager"/>
+ </component>
+
+ <component name="initializer"
+     class="nablarch.core.repository.initialization.BasicApplicationInitializer">
+   <property name="initializeList">
+     <list>
+       <!-- Other components are omitted -->
+       <component-ref name="serviceAvailability" />
+     </list>
+   </property>
  </component>
 
 .. _`service_availability-check`:

--- a/ja/application_framework/adaptors/webspheremq_adaptor.rst
+++ b/ja/application_framework/adaptors/webspheremq_adaptor.rst
@@ -58,7 +58,7 @@ IBM MQの仕様及び構築手順などは、IBM社のオフィシャルサイ�
     <property name="initializeList">
       <list>
         <!-- WmqMessagingProviderは初期化が必要 -->
-        <component-ref name="tableIdGenerator" />
+        <component-ref name="wmqMessagingProvider" />
       </list>
     </property>
   </component>

--- a/ja/application_framework/adaptors/webspheremq_adaptor.rst
+++ b/ja/application_framework/adaptors/webspheremq_adaptor.rst
@@ -31,6 +31,7 @@ IBM MQの仕様及び構築手順などは、IBM社のオフィシャルサイ�
 
 1.  ``nablarch.integration.messaging.wmq.provider.WmqMessagingProvider`` をコンポーネント設定ファイルに定義を追加する。
 2. ``1`` で設定した、 ``WmqMessagingProvider`` を :ref:`messaging_context_handler` に設定する。
+3. ``1`` で設定した、 ``WmqMessagingProvider`` は初期化が必要なので初期化対象のリストに設定する。
 
 
 以下に設定例を示す。
@@ -50,6 +51,16 @@ IBM MQの仕様及び構築手順などは、IBM社のオフィシャルサイ�
   -->
   <component class="nablarch.fw.messaging.handler.MessagingContextHandler">
     <property name="messagingProvider" ref="wmqMessagingProvider" />
+  </component>
+
+  <component name="initializer"
+      class="nablarch.core.repository.initialization.BasicApplicationInitializer">
+    <property name="initializeList">
+      <list>
+        <!-- WmqMessagingProviderは初期化が必要 -->
+        <component-ref name="tableIdGenerator" />
+      </list>
+    </property>
   </component>
 
 分散トランザクションを使用する

--- a/ja/application_framework/application_framework/handlers/standalone/process_stop_handler.rst
+++ b/ja/application_framework/application_framework/handlers/standalone/process_stop_handler.rst
@@ -66,6 +66,7 @@
 ポイント
   * 都度起動バッチで使用する場合、本ハンドラはサブスレッド側に設定する。
   * 常駐バッチで使用する場合、本ハンドラはメインスレッド側に設定する。
+  * 初期化が必要なので初期化対象のリストに設定する。
 
 .. code-block:: xml
 
@@ -83,4 +84,14 @@
 
     <!-- プロセス停止時の終了コード(任意) -->
     <property name="exitCode" value="50" />
+  </component>
+
+  <component name="initializer"
+      class="nablarch.core.repository.initialization.BasicApplicationInitializer">
+    <property name="initializeList">
+      <list>
+        <!-- 他のコンポーネントは省略 -->
+        <component-ref name="processStopHandler" />
+      </list>
+    </property>
   </component>

--- a/ja/application_framework/application_framework/libraries/code.rst
+++ b/ja/application_framework/application_framework/libraries/code.rst
@@ -145,7 +145,7 @@ female    女性     女
   ポイント
     * :java:extdoc:`BasicCodeManager <nablarch.common.code.BasicCodeManager>` のコンポーネント名は、 **codeManager** とすること。
     * :java:extdoc:`BasicStaticDataCache <nablarch.core.cache.BasicStaticDataCache>` の :java:extdoc:`loadOnStartup <nablarch.core.cache.BasicStaticDataCache.setLoadOnStartup(boolean)>` に対する設定値は、 :ref:`static_data_cache-cache_timing` を参照すること。
-    * :java:extdoc:`BasicStaticDataCache <nablarch.core.cache.BasicStaticDataCache>` は、初期化が必要なので初期化対象のリストに設定すること。
+    * :java:extdoc:`BasicCodeLoader <nablarch.common.code.BasicCodeLoader>` および :java:extdoc:`BasicStaticDataCache <nablarch.core.cache.BasicStaticDataCache>` は、初期化が必要なので初期化対象のリストに設定すること。
 
   .. code-block:: xml
 
@@ -177,11 +177,12 @@ female    女性     女
       <property name="codeDefinitionCache" ref="codeCache"/>
     </component>
 
-    <!-- BasicStaticDataCacheは初期化が必要なため初期化リストに設定する -->
+    <!-- BasicCodeLoaderとBasicStaticDataCacheは初期化が必要なため初期化リストに設定する -->
     <component name="initializer"
         class="nablarch.core.repository.initialization.BasicApplicationInitializer">
       <property name="initializeList">
         <list>
+          <component-ref name="codeLoader"/>
           <component-ref name="codeCache"/>
         </list>
       </property>

--- a/ja/application_framework/application_framework/libraries/database/generator.rst
+++ b/ja/application_framework/application_framework/libraries/database/generator.rst
@@ -92,6 +92,13 @@
 
 .. code-block:: xml
 
+  <!-- テーブル採番モジュールの設定 -->
+  <component name="tableIdGenerator" class="nablarch.common.idgenerator.TableIdGenerator">
+    <property name="tableName" value="GENERATOR" />
+    <property name="idColumnName" value="ID" />
+    <property name="noColumnName" value="NO" />
+  </component>
+
   <component name="daoContextFactory" class="nablarch.common.dao.BasicDaoContextFactory">
     <!-- シーケンス採番の設定 -->
     <property name="sequenceIdGenerator">
@@ -99,15 +106,19 @@
     </property>
 
     <!-- テーブル採番の設定 -->
-    <property name="tableIdGenerator">
-      <component class="nablarch.common.idgenerator.TableIdGenerator">
-          <property name="tableName" value="GENERATOR" />
-          <property name="idColumnName" value="ID" />
-          <property name="noColumnName" value="NO" />
-      </component>
-    </property>
+    <property name="tableIdGenerator" ref="tableIdGenerator" />
 
     <!-- 採番に関係のない設定は省略 -->
+  </component>
+
+  <component name="initializer"
+      class="nablarch.core.repository.initialization.BasicApplicationInitializer">
+    <property name="initializeList">
+      <list>
+        <!-- TableIdGeneratorは初期化が必要 -->
+        <component-ref name="tableIdGenerator" />
+      </list>
+    </property>
   </component>
 
 拡張例

--- a/ja/application_framework/application_framework/libraries/date.rst
+++ b/ja/application_framework/application_framework/libraries/date.rst
@@ -70,6 +70,8 @@
 :java:extdoc:`BasicBusinessDateProvider <nablarch.core.date.BasicBusinessDateProvider>` の設定をコンポーネント定義に追加する。
 コンポーネント名には **businessDateProvider** と指定する。
 
+また初期化が必要なので、初期化対象のリストに設定すること。
+
 .. code-block:: xml
 
  <component name="businessDateProvider" class="nablarch.core.date.BasicBusinessDateProvider">
@@ -83,6 +85,16 @@
    <property name="defaultSegment" value="00"/>
    <!-- データベースアクセスに使用するトランザクションマネージャ -->
    <property name="transactionManager" ref="transactionManager" />
+ </component>
+
+ <component name="initializer"
+     class="nablarch.core.repository.initialization.BasicApplicationInitializer">
+   <property name="initializeList">
+     <list>
+       <!-- 他のコンポーネントは省略 -->
+       <component-ref name="businessDateProvider" />
+     </list>
+   </property>
  </component>
 
 業務日付を取得する

--- a/ja/application_framework/application_framework/libraries/mail.rst
+++ b/ja/application_framework/application_framework/libraries/mail.rst
@@ -665,3 +665,13 @@
       <!-- トランザクションマネージャで指定したトランザクション名を指定 -->
       <property name="dbTransactionName" value="mail-transaction" />
   </component>
+
+  <component name="initializer"
+      class="nablarch.core.repository.initialization.BasicApplicationInitializer">
+    <property name="initializeList">
+      <list>
+        <!-- TableIdGeneratorは初期化が必要 -->
+        <component-ref name="mailRequestIdGenerator" />
+      </list>
+    </property>
+  </component>

--- a/ja/application_framework/application_framework/libraries/service_availability.rst
+++ b/ja/application_framework/application_framework/libraries/service_availability.rst
@@ -69,6 +69,8 @@
 :java:extdoc:`BasicServiceAvailability <nablarch.common.availability.BasicServiceAvailability>` の定義をコンポーネント設定ファイルに追加する。
 コンポーネント名には **serviceAvailability** と指定する。
 
+また初期化が必要なので、初期化対象のリストに設定する。
+
 .. code-block:: xml
 
  <component name="serviceAvailability" class="nablarch.common.availability.BasicServiceAvailability">
@@ -82,6 +84,16 @@
    <property name="requestTableServiceAvailableOkStatus" value="1"/>
    <!-- データベースアクセスに使用するトランザクションマネージャ -->
    <property name="dbManager" ref="serviceAvailabilityDbManager"/>
+ </component>
+
+ <component name="initializer"
+     class="nablarch.core.repository.initialization.BasicApplicationInitializer">
+   <property name="initializeList">
+     <list>
+       <!-- 他のコンポーネントは省略 -->
+       <component-ref name="serviceAvailability" />
+     </list>
+   </property>
  </component>
 
 .. _`service_availability-check`:


### PR DESCRIPTION
初期化が必要なコンポーネントなのにも関わらず、解説書に初期化に関する記載のないコンポーネントについて設定例および必要に応じて簡単な説明を追加します。

`TableIdGenerator`については、サロゲートキーのページにおいて初期化ができない（プロパティ内に直接コンポーネント定義してある）状態だったので、コンポーネント定義の構成から変更しました。

またメール送信内にも`TableIdGenerator`が登場するので、合わせて初期化例を追加しておきました。