### PR TITLE
Entityテスト用コンポーネント設定例の誤りを修正

### DIFF
--- a/en/development_tools/testing_framework/guide/development_guide/05_UnitTestGuide/01_ClassUnitTest/01_entityUnitTest/01_entityUnitTestWithBeanValidation.rst
+++ b/en/development_tools/testing_framework/guide/development_guide/05_UnitTestGuide/01_ClassUnitTest/01_entityUnitTest/01_entityUnitTestWithBeanValidation.rst
@@ -744,7 +744,7 @@ An example of a component configuration file description is shown below.
     <property name="maxAndMinMessageId"  value="{nablarch.core.validation.ee.Length.min.max.message}"/>
     <property name="fixLengthMessageId"  value="{nablarch.core.validation.ee.Length.fixed.message}"/>
     <property name="underLimitMessageId" value="{nablarch.core.validation.ee.Length.min.max.message}"/>
-    <property name="maxMessageId"        value="{nablarch.core.validation.ee.Length.min.message}"/>
+    <property name="minMessageId"        value="{nablarch.core.validation.ee.Length.min.message}"/>
     <property name="emptyInputMessageId" value="{nablarch.core.validation.ee.Required.message}"/>
     <property name="characterGenerator">
       <component name="characterGenerator"

--- a/ja/development_tools/testing_framework/guide/development_guide/05_UnitTestGuide/01_ClassUnitTest/01_entityUnitTest/01_entityUnitTestWithBeanValidation.rst
+++ b/ja/development_tools/testing_framework/guide/development_guide/05_UnitTestGuide/01_ClassUnitTest/01_entityUnitTest/01_entityUnitTestWithBeanValidation.rst
@@ -758,7 +758,7 @@ Excelへの定義
     <property name="maxAndMinMessageId"  value="{nablarch.core.validation.ee.Length.min.max.message}"/>
     <property name="fixLengthMessageId"  value="{nablarch.core.validation.ee.Length.fixed.message}"/>
     <property name="underLimitMessageId" value="{nablarch.core.validation.ee.Length.min.max.message}"/>
-    <property name="maxMessageId"        value="{nablarch.core.validation.ee.Length.min.message}"/>
+    <property name="minMessageId"        value="{nablarch.core.validation.ee.Length.min.message}"/>
     <property name="emptyInputMessageId" value="{nablarch.core.validation.ee.Required.message}"/>
     <property name="characterGenerator">
       <component name="characterGenerator"


### PR DESCRIPTION
`minMessageId`とすべきところを`maxMessageId`となっていたので修正。