### PR TITLE
Base64Utilが後方互換のために存在することを追記

### DIFF
--- a/en/application_framework/application_framework/libraries/session_store.rst
+++ b/en/application_framework/application_framework/libraries/session_store.rst
@@ -318,7 +318,7 @@ Point
   * Generate the key using :java:extdoc:`KeyGenerator <javax.crypto.KeyGenerator>`.
   * Generate IV using :java:extdoc:`SecureRandom <java.security.SecureRandom>`.
   
-  Using :java:extdoc:`java.util.Base64.Encoder` is better for base64 encoding.
+  Using :java:extdoc:`java.util.Base64.Encoder` obtained from :java:extdoc:`java.util.Base64.getEncoder()` is better for base64 encoding.
 
 Specify the transition destination screen when the value does not exist in the session variable
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/en/application_framework/application_framework/libraries/session_store.rst
+++ b/en/application_framework/application_framework/libraries/session_store.rst
@@ -318,8 +318,7 @@ Point
   * Generate the key using :java:extdoc:`KeyGenerator <javax.crypto.KeyGenerator>`.
   * Generate IV using :java:extdoc:`SecureRandom <java.security.SecureRandom>`.
   
-  Using :java:extdoc:`Base64Util <nablarch.core.util.Base64Util>` or
-  ``java.util.Base64.Encoder`` is better for base64 encoding.
+  Using :java:extdoc:`java.util.Base64.Encoder` is better for base64 encoding.
 
 Specify the transition destination screen when the value does not exist in the session variable
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/en/application_framework/application_framework/libraries/utility.rst
+++ b/en/application_framework/application_framework/libraries/utility.rst
@@ -40,7 +40,7 @@ The general-purpose utility classes provided by this framework that can be used 
 
   * - :java:extdoc:`Base64Util <nablarch.core.util.Base64Util>`
     - nablarch-core
-    - Provides the functions for Base 64 encoding
+    - Provides the functions for Base 64 encoding. :java:extdoc:`Standard APIs for Base64 encoding <java.util.Base64>` have been provided since Java 8, and this utility exists for backward compatibility.
 
   * - :java:extdoc:`BinaryUtil <nablarch.core.util.BinaryUtil>`
     - nablarch-fw-web-extension

--- a/ja/application_framework/application_framework/libraries/session_store.rst
+++ b/ja/application_framework/application_framework/libraries/session_store.rst
@@ -319,7 +319,7 @@ HIDDENストアの暗号化設定をカスタマイズする
   * :java:extdoc:`KeyGenerator <javax.crypto.KeyGenerator>` を使用して鍵を生成する。
   * :java:extdoc:`SecureRandom <java.security.SecureRandom>` を使用してIVを生成する。
   
-  なお、base64エンコードは :java:extdoc:`java.util.Base64.Encoder` を使用して行うと良い。
+  なお、base64エンコードは :java:extdoc:`java.util.Base64.getEncoder()` より取得できる :java:extdoc:`java.util.Base64.Encoder` を使用して行うと良い。
 
 セッション変数に値が存在しない場合の遷移先画面を指定する
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ja/application_framework/application_framework/libraries/session_store.rst
+++ b/ja/application_framework/application_framework/libraries/session_store.rst
@@ -319,8 +319,7 @@ HIDDENストアの暗号化設定をカスタマイズする
   * :java:extdoc:`KeyGenerator <javax.crypto.KeyGenerator>` を使用して鍵を生成する。
   * :java:extdoc:`SecureRandom <java.security.SecureRandom>` を使用してIVを生成する。
   
-  なお、base64エンコードは :java:extdoc:`Base64Util <nablarch.core.util.Base64Util>` や、
-  ``java.util.Base64.Encoder`` を使用して行うと良い。
+  なお、base64エンコードは :java:extdoc:`java.util.Base64.Encoder` を使用して行うと良い。
 
 セッション変数に値が存在しない場合の遷移先画面を指定する
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ja/application_framework/application_framework/libraries/utility.rst
+++ b/ja/application_framework/application_framework/libraries/utility.rst
@@ -40,8 +40,7 @@
 
   * - :java:extdoc:`Base64Util <nablarch.core.util.Base64Util>`
     - nablarch-core
-    - Base64エンコーディングに関する機能を提供する。
-      ※Java8以降は :java:extdoc:`Base64エンコーディングの標準API <java.util.Base64>` が提供されており、本ユーティリティは後方互換のために存在している。
+    - Base64エンコーディングに関する機能を提供する。Java8以降は :java:extdoc:`Base64エンコーディングの標準API <java.util.Base64>` が提供されており、本ユーティリティは後方互換のために存在している。
 
   * - :java:extdoc:`BinaryUtil <nablarch.core.util.BinaryUtil>`
     - nablarch-fw-web-extension

--- a/ja/application_framework/application_framework/libraries/utility.rst
+++ b/ja/application_framework/application_framework/libraries/utility.rst
@@ -40,7 +40,8 @@
 
   * - :java:extdoc:`Base64Util <nablarch.core.util.Base64Util>`
     - nablarch-core
-    - Base64エンコーディングに関する機能を提供する
+    - Base64エンコーディングに関する機能を提供する。
+      ※Java8以降は :java:extdoc:`Base64エンコーディングの標準API <java.util.Base64>` が提供されており、本ユーティリティは後方互換のために存在している。
 
   * - :java:extdoc:`BinaryUtil <nablarch.core.util.BinaryUtil>`
     - nablarch-fw-web-extension


### PR DESCRIPTION
`Base64Util`が後方互換のために存在することを追記した。
またドキュメント上で、`Base64Util`を参照する箇所では、積極的には使わせないようにするため記載を削除した。