### PR TITLE
破損したリンクの修正

### DIFF
--- a/en/application_framework/application_framework/blank_project/setup_blankProject/setup_Java21.rst
+++ b/en/application_framework/application_framework/blank_project/setup_blankProject/setup_Java21.rst
@@ -17,7 +17,7 @@ Since Java 18, the standard encoding is UTF-8, making it environment independent
 * ``-Dfile.encoding=COMPAT``
 
 .. tip::
-  When running from Maven, the environment variable `MAVEN_OPTS (external site) <https://maven.apache.org/configure.html#maven_opts-environment-variable>`_ can be used to set the JVM options. However, ``Picked up MAVEN_OPTS: -Dfile.encoding=COMPAT`` is displayed in the log.
+  When running from Maven, the environment variable `MAVEN_OPTS (external site) <https://maven.apache.org/configure.html#MAVEN_OPTS_environment_variable.3A>`_ can be used to set the JVM options. However, ``Picked up MAVEN_OPTS: -Dfile.encoding=COMPAT`` is displayed in the log.
   Please note that the settings for JVM options may differ depending on Maven plugin.(For example, in maven-surefire-plugin that runs the test, it needs to be specified in ``argLine`` in plugin settings in pom.xml)
 
 .. important::

--- a/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Java21.rst
+++ b/ja/application_framework/application_framework/blank_project/setup_blankProject/setup_Java21.rst
@@ -18,7 +18,7 @@ Java18から標準エンコーディングがUTF-8に統一され、環境依存
 * ``-Dfile.encoding=COMPAT``
 
 .. tip::
-  Mavenから実行する場合は、環境変数 `MAVEN_OPTS (外部サイト) <https://maven.apache.org/configure.html#maven_opts-environment-variable>`_ を使うことでJVMオプションを設定できる。ただしログに ``Picked up MAVEN_OPTS: -Dfile.encoding=COMPAT`` が表示される。
+  Mavenから実行する場合は、環境変数 `MAVEN_OPTS (外部サイト) <https://maven.apache.org/configure.html#MAVEN_OPTS_environment_variable.3A>`_ を使うことでJVMオプションを設定できる。ただしログに ``Picked up MAVEN_OPTS: -Dfile.encoding=COMPAT`` が表示される。
   なお、MavenプラグインによってはJVMオプションの設定方法が異なる場合があるため注意すること。（例えばテストを実行するmaven-surefire-pluginでは、pom.xmlのプラグイン設定にある ``argLine`` で指定する必要がある）
 
 .. important::


### PR DESCRIPTION
MAVEN_OPTSの外部ドキュメントへのリンクが破損していたことを検知したので修正しました。