### PR TITLE
Nablarch 6u2はgsp-dba-maven-plugin 5.1.0を前提としている記述に変更

### DIFF
--- a/en/migration/index.rst
+++ b/en/migration/index.rst
@@ -11,6 +11,7 @@ This document will explain how to migration a project created with Nablarch 5 to
 .. important::
   Nablarch 6 version 6/6u1 is a pre-release version, and 6u2 will be the first version after the official release.
   Therefore, the procedures described here assume that you are upgrading from the latest version of Nablarch 5 to Nablarch 6u2.
+  In addition, the gsp-dba-maven-plugin that is preinstalled in projects created from archetypes assumes the use of 5.1.0, which was released together with 6u2.
   When upgrading to 6u3 or later, additional steps may be required in addition to those explained here.
   Be sure to check the upgrade procedure by referring to the release notes for 6u3 or later in order.
 
@@ -440,7 +441,7 @@ Update gsp-dba-maven-plugin
 This plugin provides a function (``generate-entity``) to generate Java entity classes from database table metadata.
 Since Java EE annotations such as JPA are set in this entity class, it cannot be used as is in the Jakarta EE environment.
 
-Since gsp-dba-maven-plugin is compatible with Jakarta EE in 5.0.0, change ``<version>`` of gsp-dba-maven-plugin in ``pom.xml``.
+Since gsp-dba-maven-plugin is compatible with Jakarta EE and Nablarch 6u2 in 5.1.0, change ``<version>`` of gsp-dba-maven-plugin in ``pom.xml``.
 
 .. code-block:: xml
 

--- a/ja/migration/index.rst
+++ b/ja/migration/index.rst
@@ -11,6 +11,7 @@ Nablarch 5から6への移行ガイド
 .. important::
   Nablarch 6のバージョン 6/6u1 は先行リリースバージョンであり、6u2が正式リリース後の最初のバージョンとなる。
   そのため、ここで説明する手順は、Nablarch 5の最新バージョンからNablarch 6u2へのバージョンアップを前提としている。
+  またアーキタイプから作ったプロジェクトなどに組み込まれているgsp-dba-maven-pluginは、6u2と合わせてリリースされた5.1.0の使用を前提としている。
   6u3以降へバージョンアップする場合は、ここで説明する手順以外にも追加の手順が必要となる場合があるため、6u3以降のリリースノートを順に参照してバージョンアップ手順を必ず確認すること。
 
 Nablarch 5と6で大きく異なる点
@@ -439,7 +440,7 @@ nablarch-example-webをはじめ、アーキタイプから作ったプロジェ
 このプラグインは、データベーステーブルのメタデータからJavaのエンティティクラスを生成する機能(``generate-entity``)を提供している。
 このエンティティクラスにはJPAなどのJava EEのアノテーションが設定されるため、そのままではJakarta EE環境で使用できない。
 
-gsp-dba-maven-pluginは5.0.0でJakarta EE対応が入ったので、 ``pom.xml`` でgsp-dba-maven-pluginの ``<version>`` を変更する。
+gsp-dba-maven-pluginは5.1.0でJakarta EEおよびNablarch 6u2へ対応したので、 ``pom.xml`` でgsp-dba-maven-pluginの ``<version>`` を変更する。
 
 .. code-block:: xml
 


### PR DESCRIPTION
https://github.com/coastland/gsp-dba-maven-plugin/pull/215 によるgsp-dba-maven-pluginのバージョンアップによる対応。

ただ、解説書ではgsp-dba-maven-pluginのバージョンアップに追従するのではなく、現在のNablarchに対応している最新版を利用する方針とし、解説書では固定のバージョンで記載する。

一方でマイグレーションガイドではJakarta EE対応版と6u2への対応版の整合が取れていなかったので、前提とgsp-dba-maven-pluginのセクションに6u2との関連性を追記した。