### PR TITLE
解説書ビルド環境と同一のドキュメント構造となるようパッケージのバージョンを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ COPY package*.json /root/
 COPY patches /root/patches/
 
 # Sphinxのセットアップ
-RUN pip install setuptools==45
 RUN pip install --no-cache-dir -r requirements.txt
 
 # textlintのセットアップ

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY package*.json /root/
 COPY patches /root/patches/
 
 # Sphinxのセットアップ
+RUN pip install setuptools==45
 RUN pip install --no-cache-dir -r requirements.txt
 
 # textlintのセットアップ

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-alabaster==0.7.13
+alabaster==0.7.12
 Babel==2.15.0
 beautifulsoup4==4.12.3
 certifi==2024.7.4
 charset-normalizer==3.3.2
-docutils==0.20.1
+docutils==0.15.2
 docutils-ast-writer==0.1.2
 future==1.0.0
 idna==3.7
@@ -13,13 +13,13 @@ javasphinx==0.9.15
 Jinja2==3.0.3
 lxml==5.2.2
 MarkupSafe==2.1.5
-Pygments==2.18.0
+Pygments==2.4.2
 pytz==2024.1
 requests==2.32.3
 six==1.16.0
 snowballstemmer==2.2.0
 soupsieve==2.5
-Sphinx==1.6.3
+Sphinx==1.3.6
 sphinx-rtd-theme==0.2.4
 sphinxcontrib-serializinghtml==1.1.5
 sphinxcontrib-websupport==1.2.4


### PR DESCRIPTION
解説書ビルド環境でビルドした解説書と、本リポジトリに記載の手順で用意した環境でビルドした解説書で、ドキュメント構造（html）に差分が発生することを検出した。
原因は、解説書ビルド環境と本リポジトリの案内で、インストールしているPythonパッケージのバージョンに差があったためである。

今回のプルリクエストで、解説書ビルド環境のビルド結果と同じhtmlとなるように、インストールするパッケージのバージョンを変更した。
`alabaster==0.7.13`は`Sphinx>=1.6`を要求するため、合わせてバージョンを変更した。
本変更内容で、ローカル環境でビルド用コンテナイメージを作成できることを確認済み。
また、本リポジトリの手順に従ってビルドした結果のhtmlが、解説書ビルド環境のものと同一であることを確認済み。