### PR TITLE
解説書ビルド環境と同一のドキュメント構造となるようパッケージのバージョンを修正

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-alabaster==0.7.13
+alabaster==0.7.12
 Babel==2.15.0
 beautifulsoup4==4.12.3
 certifi==2024.7.4
 charset-normalizer==3.3.2
-docutils==0.20.1
+docutils==0.15.2
 docutils-ast-writer==0.1.2
 future==1.0.0
 idna==3.7
@@ -13,13 +13,13 @@ javasphinx==0.9.15
 Jinja2==3.0.3
 lxml==5.2.2
 MarkupSafe==2.1.5
-Pygments==2.18.0
+Pygments==2.4.2
 pytz==2024.1
 requests==2.32.3
 six==1.16.0
 snowballstemmer==2.2.0
 soupsieve==2.5
-Sphinx==1.6.3
+Sphinx==1.3.6
 sphinx-rtd-theme==0.2.4
 sphinxcontrib-serializinghtml==1.1.5
 sphinxcontrib-websupport==1.2.4


### PR DESCRIPTION
Pull Request 687の内容を5系にcherry-pickで反映。

リリースされているドキュメントのビルド環境と、`requirements.txt`に記述されていたPythonライブラリのバージョンに差があり、生成されるドキュメントに差が生じていたため、ライブラリのバージョンをビルド環境のものと合うように修正。

修正内容自体は6系で行ったものと同じであり、現在のビルド環境とで生成したものと、本PRで変更したライブラリを使って生成したもので結果が同じになることを確認済み。

なお、変更前は一例として以下のような差分が出ていた（idの命名ルールが異なる）。

```shell
273,276c270,273
< <li class="toctree-l3"><a class="reference internal" href="../biz_samples/12/index.html#section-1">提供パッケージ</a></li>
< <li class="toctree-l3"><a class="reference internal" href="../biz_samples/12/index.html#section-2">概要</a></li>
< <li class="toctree-l3"><a class="reference internal" href="../biz_samples/12/index.html#section-4">構成</a></li>
< <li class="toctree-l3"><a class="reference internal" href="../biz_samples/12/index.html#section-10">使用方法</a></li>
---
> <li class="toctree-l3"><a class="reference internal" href="../biz_samples/12/index.html#id1">提供パッケージ</a></li>
> <li class="toctree-l3"><a class="reference internal" href="../biz_samples/12/index.html#id3">概要</a></li>
> <li class="toctree-l3"><a class="reference internal" href="../biz_samples/12/index.html#id5">構成</a></li>
> <li class="toctree-l3"><a class="reference internal" href="../biz_samples/12/index.html#id11">使用方法</a></li>
```

その他、スタイルや生成されるファイルの数にも差があったが、これが一切なくなった。