### PR TITLE
ルート定義の再読込とチェックについて解説書に記載がなかったため追記

### DIFF
--- a/en/application_framework/adaptors/router_adaptor.rst
+++ b/en/application_framework/adaptors/router_adaptor.rst
@@ -71,6 +71,19 @@ Creates `routes.xml` directly under the class path and configures the configurat
 
 For the configuration method to the route definition file, see `Library README document (external site) <https://github.com/kawasima/http-request-router/blob/master/README.ja.md>`_ .
 
+The route definition file is loaded at the following timing.
+
+* When initializing :java:extdoc:`RoutesMapping <nablarch.integration.router.RoutesMapping>`
+* When the route definition file reload setting is enabled and all of the following conditions are met:
+
+  * The specified number of seconds has passed since the route definition file was last loaded
+  * Mapping of URLs and business actions is performed
+  * The route definition file has been changed
+
+To enable reloading of route definition files, specify a value greater than or equal to 0 in :java:extdoc:`RoutesMapping#setCheckInterval(long) <nablarch.integration.router.RoutesMapping.setCheckInterval(long)>` .
+
+The unit of specification for :java:extdoc:`RoutesMapping#setCheckInterval(long) <nablarch.integration.router.RoutesMapping.setCheckInterval(long)>` is seconds. In environments where performance is important, we recommend specifying -1 to disable checking for changes in the route definition file.
+
 Automatically map business actions and URLs
 --------------------------------------------------------
 Business action and URL can be automatically mapped by using parameters such as ``:controller`` and ``:action`` in the path attribute of `match` tag in the route definition file.

--- a/ja/application_framework/adaptors/router_adaptor.rst
+++ b/ja/application_framework/adaptors/router_adaptor.rst
@@ -76,6 +76,19 @@
 
 ルート定義ファイルへの設定方法は、`ライブラリのREADMEドキュメント(外部サイト) <https://github.com/kawasima/http-request-router/blob/master/README.ja.md>`_ を参照。
 
+ルート定義ファイルは以下のタイミングで読み込まれる。
+
+* :java:extdoc:`RoutesMapping <nablarch.integration.router.RoutesMapping>` の初期化時
+* ルート定義ファイル再読み込みの設定が有効であり、以下のすべての条件を満たしている時
+
+  * 最後にルート定義ファイルを読み込んでから指定された秒数が経過している
+  * URLと業務アクションのマッピング処理が行われている
+  * ルート定義ファイルが変更されている
+
+ルート定義ファイルの再読み込みを有効にするには、 :java:extdoc:`RoutesMapping#setCheckInterval(long) <nablarch.integration.router.RoutesMapping.setCheckInterval(long)>` に0以上の値を指定する。
+
+:java:extdoc:`RoutesMapping#setCheckInterval(long) <nablarch.integration.router.RoutesMapping.setCheckInterval(long)>` の指定単位は秒数となる。パフォーマンスを重視する環境では-1を指定し、ルート定義ファイルの変更確認を行わないよう設定することを推奨する。
+
 業務アクションとURLを自動的にマッピングする
 --------------------------------------------------------
 ルート定義ファイルにて、 `match` タグのpath属性に ``:controller`` や ``:action``


### PR DESCRIPTION
Pull Request 698の5系へのバックポートです。

日本語版、英語版ともにルート定義ファイルの再読み込みについて記載がなかったため、機能そのものの説明と再読み込み条件を明示するようにしました。