### PR TITLE
実装サンプル集へのリンク先が5系になるように修正

### DIFF
--- a/_templates/breadcrumbs.html
+++ b/_templates/breadcrumbs.html
@@ -18,10 +18,10 @@
     </li>
     <li class="wy-breadcrumbs-aside">
       {%- if language != "en" %}
-        <a href="https://nablarch.github.io/docs/LATEST/doc/en/index.html" class="en">English</a>
+        <a href="https://nablarch.github.io/docs/5-LATEST/doc/en/index.html" class="en">English</a>
       {%- endif %}
       {%- if language != "ja" %}
-        <a href="https://nablarch.github.io/docs/LATEST/doc/index.html" class="ja">日本語</a>
+        <a href="https://nablarch.github.io/docs/5-LATEST/doc/index.html" class="ja">日本語</a>
       {%- endif %}
     </li>
   </ul>

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -2,6 +2,7 @@
 {% extends "!layout.html" %}
 
 {% block linktags %}
+  {# canonicalは最新バージョンの解説書を参照する #}
   <link rel="canonical" href="https://nablarch.github.io/docs/LATEST/doc/{{ pagename }}.html" />
   {{ super() }}
 {% endblock %}

--- a/en/about_nablarch/versionup_policy.rst
+++ b/en/about_nablarch/versionup_policy.rst
@@ -190,5 +190,5 @@ If any of the following applies, we may upgrade the version so that backward com
 * When a framework bug is detected and cannot be fixed while maintaining backward compatibility.
 * When a problem occurs due to a version upgrade of JDK, which is the environment in which the framework operates, and it cannot be fixed while maintaining backward compatibility.
 
-If we make changes that don't maintain backward compatibility, we'll explain what they're doing and how to deal with them in the "Impact on the system and how to deal with it(システムへの影響の可能性の内容と対処)" section of the `Release Notes(Japanese Page) <https://nablarch.github.io/docs/LATEST/doc/releases/index.html>`_.
+If we make changes that don't maintain backward compatibility, we'll explain what they're doing and how to deal with them in the "Impact on the system and how to deal with it(システムへの影響の可能性の内容と対処)" section of the `Release Notes(Japanese Page) <https://nablarch.github.io/docs/5-LATEST/doc/releases/index.html>`_.
 

--- a/en/biz_samples/01/index.rst
+++ b/en/biz_samples/01/index.rst
@@ -11,7 +11,7 @@ This is an implementation sample that performs authentication process using acco
 
   0101_PBKDF2PasswordEncryptor
 
-`Source code <https://github.com/nablarch/nablarch-biz-sample-all>`_
+`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/v5-main>`_
 
 
 -------------------

--- a/en/biz_samples/03/index.rst
+++ b/en/biz_samples/03/index.rst
@@ -6,7 +6,7 @@ Display a List of Search Results
 
 This sample is an implementation sample of the tag file that displays a list of search results.
 
-`Source code <https://github.com/nablarch/nablarch-biz-sample-all>`_
+`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/v5-main>`_
 
 -----------------
 Delivery package

--- a/en/biz_samples/04/index.rst
+++ b/en/biz_samples/04/index.rst
@@ -15,4 +15,4 @@ Extended Formatter Functions
   0401_ExtendedDataFormatter
   0402_ExtendedFieldType
   
-`Source code <https://github.com/nablarch/nablarch-biz-sample-all>`_
+`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/v5-main>`_

--- a/en/biz_samples/05/index.rst
+++ b/en/biz_samples/05/index.rst
@@ -11,7 +11,7 @@ Summary
 
 Provides an implementation sample of the function to centrally manage the files used in business applications with DB.
 
-`Source code <https://github.com/nablarch/nablarch-biz-sample-all>`_
+`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/v5-main>`_
 
 The sample is intended for the following applications:
 

--- a/en/biz_samples/08/index.rst
+++ b/en/biz_samples/08/index.rst
@@ -7,7 +7,7 @@ Summary
 
 Provides the implementation sample of the function that sends the HTML email.
 
-`Source code <https://github.com/nablarch/nablarch-biz-sample-all>`_
+`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/v5-main>`_
 
 This function is a sample to send HTML mail using :ref:`mail` .
 Since this function is a sample implementation, the source code (both production and test code) must be imported into the project when using it in an implementation project.

--- a/en/biz_samples/12/index.rst
+++ b/en/biz_samples/12/index.rst
@@ -7,7 +7,7 @@ Authentication sample using OIDC ID token
 Delivery package
 -----------------
 
-`Source code <https://github.com/nablarch/nablarch-biz-sample-all>`_
+`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/v5-main>`_
 
 The sample is provided in the following package.
 

--- a/en/biz_samples/13/index.rst
+++ b/en/biz_samples/13/index.rst
@@ -7,7 +7,7 @@ Sample Request/Response Log Output Using Logbook
 Delivery package
 ------------------
 
-`Source code <https://github.com/nablarch/nablarch-biz-sample-all>`_
+`Source code <https://github.com/nablarch/nablarch-biz-sample-all/tree/v5-main>`_
 
 The sample is provided in the following package.
 

--- a/en/development_tools/ui_dev/index.rst
+++ b/en/development_tools/ui_dev/index.rst
@@ -4,6 +4,6 @@ Front-end UI development platform for advanced users
 
 Only japanese edition
 
-See `Front-end UI development platform for advanced users(Japanese Page) <https://nablarch.github.io/docs/LATEST/doc/development_tools/ui_dev/index.html>`_
+See `Front-end UI development platform for advanced users(Japanese Page) <https://nablarch.github.io/docs/5-LATEST/doc/development_tools/ui_dev/index.html>`_
 
 

--- a/en/extension_components/etl/etl_maven_plugin.rst
+++ b/en/extension_components/etl/etl_maven_plugin.rst
@@ -5,6 +5,6 @@ ETL Maven plugin
 
 Only japanese edition
 
-See `ETL Maven plugin(Japanese Page) <https://nablarch.github.io/docs/LATEST/doc/extension_components/etl/etl_maven_plugin.html>`_
+See `ETL Maven plugin(Japanese Page) <https://nablarch.github.io/docs/5-LATEST/doc/extension_components/etl/etl_maven_plugin.html>`_
 
 

--- a/en/extension_components/etl/index.rst
+++ b/en/extension_components/etl/index.rst
@@ -5,6 +5,6 @@ ETL
 
 Only japanese edition
 
-See `ETL(Japanese Page) <https://nablarch.github.io/docs/LATEST/doc/extension_components/etl/index.html>`_
+See `ETL(Japanese Page) <https://nablarch.github.io/docs/5-LATEST/doc/extension_components/etl/index.html>`_
 
 

--- a/en/extension_components/report/index.rst
+++ b/en/extension_components/report/index.rst
@@ -4,6 +4,6 @@ Form library
 
 Only japanese edition
 
-See `Form library(Japanese Page) <https://nablarch.github.io/docs/LATEST/doc/extension_components/report/index.html>`_
+See `Form library(Japanese Page) <https://nablarch.github.io/docs/5-LATEST/doc/extension_components/report/index.html>`_
 
 

--- a/en/extension_components/workflow/doc/index.rst
+++ b/en/extension_components/workflow/doc/index.rst
@@ -5,7 +5,7 @@ Workflow library
 
 Only japanese edition
 
-See `Workflow library(Japanese Page) <https://nablarch.github.io/docs/LATEST/doc/extension_components/workflow/doc/index.html>`_
+See `Workflow library(Japanese Page) <https://nablarch.github.io/docs/5-LATEST/doc/extension_components/workflow/doc/index.html>`_
 
 
 

--- a/en/extension_components/workflow/tool/index.rst
+++ b/en/extension_components/workflow/tool/index.rst
@@ -5,6 +5,6 @@ Workflow definition data generation tool
 
 Only japanese edition
 
-See `Workflow definition data generation tool(Japanese Page) <https://nablarch.github.io/docs/LATEST/doc/extension_components/workflow/tool/index.html>`_
+See `Workflow definition data generation tool(Japanese Page) <https://nablarch.github.io/docs/5-LATEST/doc/extension_components/workflow/tool/index.html>`_
 
 

--- a/en/terms_of_use/index.rst
+++ b/en/terms_of_use/index.rst
@@ -38,7 +38,7 @@ The information we collect and its specific uses are as follows:
      - Usage
 
    * - Page URL
-     - `https://nablarch.github.io/docs/LATEST​/doc/en/index.html <https://nablarch.github.io/docs/LATEST/doc/en/index.html>`_
+     - `https://nablarch.github.io/docs/5-LATEST​/doc/en/index.html <https://nablarch.github.io/docs/5-LATEST/doc/en/index.html>`_
      - URL of This Website
      - Used to measure which pages have been viewed.
 

--- a/en/terms_of_use/index.rst
+++ b/en/terms_of_use/index.rst
@@ -38,7 +38,7 @@ The information we collect and its specific uses are as follows:
      - Usage
 
    * - Page URL
-     - `https://nablarch.github.io/docs/5-LATEST​/doc/en/index.html <https://nablarch.github.io/docs/5-LATEST/doc/en/index.html>`_
+     - `https://nablarch.github.io/docs/LATEST​/doc/en/index.html <https://nablarch.github.io/docs/LATEST/doc/en/index.html>`_
      - URL of This Website
      - Used to measure which pages have been viewed.
 

--- a/ja/biz_samples/01/index.rst
+++ b/ja/biz_samples/01/index.rst
@@ -11,7 +11,7 @@
 
   0101_PBKDF2PasswordEncryptor
 
-`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all>`_
+`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/v5-main>`_
 
 
 --------------

--- a/ja/biz_samples/03/index.rst
+++ b/ja/biz_samples/03/index.rst
@@ -6,7 +6,7 @@
 
 本サンプルは、検索結果の一覧表示を行うタグファイルの実装サンプルである。
 
-`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all>`_
+`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/v5-main>`_
 
 --------------
 提供パッケージ

--- a/ja/biz_samples/04/index.rst
+++ b/ja/biz_samples/04/index.rst
@@ -8,4 +8,4 @@
   0401_ExtendedDataFormatter
   0402_ExtendedFieldType
   
-`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all>`_
+`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/v5-main>`_

--- a/ja/biz_samples/05/index.rst
+++ b/ja/biz_samples/05/index.rst
@@ -10,7 +10,7 @@
 
 業務アプリケーションにて使用するファイルを、DBで一元管理するための機能の実装サンプルを提供する。
 
-`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all>`_
+`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/v5-main>`_
 
 本サンプルは以下の用途を想定している。
 

--- a/ja/biz_samples/08/index.rst
+++ b/ja/biz_samples/08/index.rst
@@ -7,7 +7,7 @@ HTMLメール送信機能サンプル
 
 HTMLメールを送信する機能の実装サンプルを提供する。
 
-`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all>`_
+`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/v5-main>`_
 
 本機能は、:ref:`メール送信機能<mail>` を使用してHTMLメールを送信するサンプルである。
 なお、本機能はサンプル実装のため、導入プロジェクトで使用する際には、ソースコード(プロダクション、テストコード共に）をプロジェクトに取り込み、使用すること。

--- a/ja/biz_samples/12/index.rst
+++ b/ja/biz_samples/12/index.rst
@@ -7,7 +7,7 @@ OIDCのIDトークンを用いた認証サンプル
 提供パッケージ
 --------------
 
-`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all>`_
+`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/v5-main>`_
 
 本サンプルは、以下のパッケージで提供される。
 

--- a/ja/biz_samples/13/index.rst
+++ b/ja/biz_samples/13/index.rst
@@ -7,7 +7,7 @@ Logbookを用いたリクエスト/レスポンスログ出力サンプル
 提供パッケージ
 --------------
 
-`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all>`_
+`ソースコード <https://github.com/nablarch/nablarch-biz-sample-all/tree/v5-main>`_
 
 本サンプルは、以下のパッケージで提供される。
 


### PR DESCRIPTION
解説書の実装サンプル集のリンクがGitHubリポジトリのデフォルトブランチを参照していたため、リンク先に遷移すると5系の解説書であるにも関わらず6系のサンプルコードを参照することになっていた。

このため、5系の解説書では`v5-main`ブランチを参照するようにブランチを明示的に指定。

加えて、類似の問題として以下を修正。

- 英語版の拡張コンポーネントの解説が日本語版をURL指定で参照していたが、このURLが`LATEST`（6系）だったため`5-LATEST`になるように修正
- 英語版のアップグレードポリシーもリリースノートの日本語版をURL指定で参照していたので、同様の修正を実施
- パンくず部の日本語版、英語版への切り替えが`LATEST`を参照していたので、`5-LATEST`になるよう修正

canonicalに関しては、6系を正とした方がよいと思われるのでコメントを追加。  
※5系のみに存在するコンテンツは微妙だが、canonicalがバージョンごとに乱立するのもよろしくない…